### PR TITLE
feat(windows): 完成 Windows 11 x64 第一阶段适配

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ AgentKib 会区分“已安装”和“只发现了卸载后的本地数据”�
 | Fedora x64 | CI 构建并验证 `.rpm` |
 | Windows ARM64 / Linux ARM64 | Preview；保证核心编译或原生打包，部分额度能力可能不可用 |
 
+Windows 11 x64 的完整环境安装、开发启动、NSIS 打包和使用步骤见 [Windows 构建、安装与使用指南](docs/WINDOWS.md)。
+
 ### 从源码运行
 
 需要 Rust stable、Node.js 和 pnpm 10。桌面端还需要对应平台的 [Tauri 2 系统依赖](https://v2.tauri.app/start/prerequisites/)：macOS 使用 Xcode Command Line Tools，Windows 使用 Visual Studio Build Tools 2022 与 Windows SDK，Linux 使用 GTK 3、WebKitGTK 4.1、AppIndicator、librsvg 和 libxdo。

--- a/apps/desktop/scripts/diagnose-windows.ps1
+++ b/apps/desktop/scripts/diagnose-windows.ps1
@@ -34,10 +34,16 @@ function Get-CommandOutput {
 
 $os = Get-CimInstance Win32_OperatingSystem
 $architecture = $os.OSArchitecture
-if ($architecture -match "64") {
-  Add-Result "Windows x64" "PASS" "$($os.Caption) $($os.Version) ($architecture)"
+$buildNumber = 0
+$hasBuildNumber = [int]::TryParse([string] $os.BuildNumber, [ref] $buildNumber)
+$isWindows11 = $hasBuildNumber -and $os.ProductType -eq 1 -and $buildNumber -ge 22000
+$isX64 = $architecture -match "64"
+$osDetail = "$($os.Caption) $($os.Version) build $($os.BuildNumber) ($architecture)"
+
+if ($isWindows11 -and $isX64) {
+  Add-Result "Windows 11 x64" "PASS" $osDetail
 } else {
-  Add-Result "Windows x64" "FAIL" "Windows 11 x64 is required; current architecture: $architecture"
+  Add-Result "Windows 11 x64" "FAIL" "Windows 11 x64 is required; current system: $osDetail"
 }
 
 $gitVersion = Get-CommandOutput "git" @("--version")

--- a/apps/desktop/scripts/diagnose-windows.ps1
+++ b/apps/desktop/scripts/diagnose-windows.ps1
@@ -1,0 +1,157 @@
+param()
+
+$ErrorActionPreference = "Stop"
+$results = [System.Collections.Generic.List[object]]::new()
+
+function Add-Result {
+  param(
+    [Parameter(Mandatory = $true)][string] $Check,
+    [Parameter(Mandatory = $true)][ValidateSet("PASS", "WARN", "FAIL")][string] $Status,
+    [Parameter(Mandatory = $true)][string] $Detail
+  )
+  $results.Add([PSCustomObject]@{
+      Check = $Check
+      Status = $Status
+      Detail = $Detail
+    })
+}
+
+function Get-CommandOutput {
+  param(
+    [Parameter(Mandatory = $true)][string] $Command,
+    [string[]] $Arguments = @()
+  )
+  $resolved = Get-Command $Command -ErrorAction SilentlyContinue
+  if (-not $resolved) {
+    return $null
+  }
+  $output = & $resolved.Source @Arguments 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    return $null
+  }
+  return ($output | Out-String).Trim()
+}
+
+$os = Get-CimInstance Win32_OperatingSystem
+$architecture = $os.OSArchitecture
+if ($architecture -match "64") {
+  Add-Result "Windows x64" "PASS" "$($os.Caption) $($os.Version) ($architecture)"
+} else {
+  Add-Result "Windows x64" "FAIL" "Windows 11 x64 is required; current architecture: $architecture"
+}
+
+$gitVersion = Get-CommandOutput "git" @("--version")
+if ($gitVersion) {
+  Add-Result "Git" "PASS" $gitVersion
+} else {
+  Add-Result "Git" "FAIL" "Git was not found. Install Git for Windows and reopen the terminal."
+}
+
+$nodeVersion = Get-CommandOutput "node" @("--version")
+if ($nodeVersion -and $nodeVersion -match "^v22\.") {
+  Add-Result "Node.js 22" "PASS" $nodeVersion
+} elseif ($nodeVersion) {
+  Add-Result "Node.js 22" "FAIL" "Found $nodeVersion; this project and CI require Node.js 22."
+} else {
+  Add-Result "Node.js 22" "FAIL" "Node.js was not found. Install OpenJS.NodeJS.22 and reopen the terminal."
+}
+
+$pnpmVersion = Get-CommandOutput "pnpm" @("--version")
+if ($pnpmVersion -eq "10.8.1") {
+  Add-Result "pnpm 10.8.1" "PASS" $pnpmVersion
+} elseif ($pnpmVersion) {
+  Add-Result "pnpm 10.8.1" "FAIL" "Found $pnpmVersion; run: corepack prepare pnpm@10.8.1 --activate"
+} else {
+  Add-Result "pnpm 10.8.1" "FAIL" "pnpm was not found. Install Node.js 22 and enable Corepack."
+}
+
+$rustVersion = Get-CommandOutput "rustc" @("--version")
+$cargoVersion = Get-CommandOutput "cargo" @("--version")
+$rustVerbose = Get-CommandOutput "rustc" @("-vV")
+if ($rustVersion -and $cargoVersion -and $rustVerbose -match "host:\s+x86_64-pc-windows-msvc") {
+  Add-Result "Rust stable MSVC" "PASS" "$rustVersion; $cargoVersion"
+} elseif ($rustVersion) {
+  Add-Result "Rust stable MSVC" "FAIL" "Rust is installed, but the default host is not x86_64-pc-windows-msvc."
+} else {
+  Add-Result "Rust stable MSVC" "FAIL" "Rust was not found. Install Rustup and select stable-msvc."
+}
+
+$installedTargets = Get-CommandOutput "rustup" @("target", "list", "--installed")
+if ($installedTargets -match "(?m)^x86_64-pc-windows-msvc$") {
+  Add-Result "Rust Windows target" "PASS" "x86_64-pc-windows-msvc"
+} else {
+  Add-Result "Rust Windows target" "FAIL" "Run: rustup target add x86_64-pc-windows-msvc"
+}
+
+$rustfmtVersion = Get-CommandOutput "cargo" @("fmt", "--version")
+$clippyVersion = Get-CommandOutput "cargo" @("clippy", "--version")
+if ($rustfmtVersion -and $clippyVersion) {
+  Add-Result "rustfmt + clippy" "PASS" "$rustfmtVersion; $clippyVersion"
+} else {
+  Add-Result "rustfmt + clippy" "FAIL" "Run: rustup component add rustfmt clippy"
+}
+
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+$buildToolsPath = $null
+if (Test-Path -LiteralPath $vswhere) {
+  $buildToolsPath = (& $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath | Select-Object -First 1)
+}
+if ($buildToolsPath) {
+  Add-Result "MSVC Build Tools" "PASS" $buildToolsPath
+} else {
+  Add-Result "MSVC Build Tools" "FAIL" "Install Visual Studio Build Tools 2022 with Desktop development with C++."
+}
+
+$sdkRoot = "${env:ProgramFiles(x86)}\Windows Kits\10\Lib"
+$sdkVersion = $null
+if (Test-Path -LiteralPath $sdkRoot) {
+  $sdkVersion = Get-ChildItem -LiteralPath $sdkRoot -Directory |
+    Sort-Object Name -Descending |
+    Select-Object -First 1 -ExpandProperty Name
+}
+if ($sdkVersion) {
+  Add-Result "Windows SDK" "PASS" $sdkVersion
+} else {
+  Add-Result "Windows SDK" "FAIL" "Windows SDK was not found. Add it with the Build Tools installer."
+}
+
+$webView = @(
+  "HKLM:\SOFTWARE\Microsoft\EdgeUpdate\Clients",
+  "HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients",
+  "HKCU:\SOFTWARE\Microsoft\EdgeUpdate\Clients"
+) | ForEach-Object {
+  Get-ChildItem -Path $_ -ErrorAction SilentlyContinue | ForEach-Object {
+    Get-ItemProperty $_.PSPath
+  }
+} | Where-Object { $_.name -match "WebView2" } | Select-Object -First 1
+if ($webView) {
+  Add-Result "WebView2 Runtime" "PASS" "$($webView.name) $($webView.pv)"
+} else {
+  Add-Result "WebView2 Runtime" "FAIL" "WebView2 Evergreen Runtime was not found."
+}
+
+if ($gitVersion) {
+  & cmd.exe /D /C "git ls-remote https://github.com/starroyhq/agentkib.git refs/heads/main >nul 2>&1"
+  $gitConnectionExitCode = $LASTEXITCODE
+  if ($gitConnectionExitCode -eq 0) {
+    Add-Result "GitHub Git connection" "PASS" "The upstream repository is reachable."
+  } else {
+    Add-Result "GitHub Git connection" "FAIL" "Git cannot reach GitHub. Check Clash and the GitHub-specific Git proxy."
+  }
+}
+
+try {
+  Invoke-WebRequest -UseBasicParsing -Method Head -TimeoutSec 10 -Uri "https://index.crates.io/config.json" | Out-Null
+  Add-Result "Cargo registry connection" "PASS" "index.crates.io is reachable."
+} catch {
+  Add-Result "Cargo registry connection" "WARN" "crates.io is unreachable; HTTPS_PROXY may be required while building."
+}
+
+$results | Format-Table -AutoSize -Wrap
+$failures = @($results | Where-Object Status -eq "FAIL")
+$warnings = @($results | Where-Object Status -eq "WARN")
+Write-Output ""
+Write-Output "Summary: $($results.Count - $failures.Count - $warnings.Count) passed, $($warnings.Count) warnings, $($failures.Count) failed."
+if ($failures.Count -gt 0) {
+  exit 1
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -72,6 +72,7 @@ use tauri_plugin_shell::{ShellExt, process::CommandEvent};
 
 mod i18n;
 mod obsidian;
+mod platform;
 mod refresh;
 use i18n::{LocalePreference, SupportedLocale, translate};
 use obsidian::{ObsidianIntegration, ObsidianWorkspaceLink};
@@ -1496,39 +1497,16 @@ fn runtime_info(
 
 #[tauri::command]
 fn open_files_and_folders_settings() -> CommandResult<()> {
-    #[cfg(target_os = "macos")]
-    {
-        const FILES_AND_FOLDERS_SETTINGS_URL: &str =
-            "x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders";
-        std::process::Command::new("/usr/bin/open")
-            .arg(FILES_AND_FOLDERS_SETTINGS_URL)
-            .spawn()
-            .map_err(|error| {
-                LocalizedMessage::with_detail("errors.openSystemSettings", error.to_string())
-            })?;
-        Ok(())
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        std::process::Command::new("cmd.exe")
-            .args([
-                "/D",
-                "/C",
-                "start",
-                "",
-                "ms-settings:privacy-broadfilesystemaccess",
-            ])
-            .spawn()
-            .map_err(|error| {
-                LocalizedMessage::with_detail("errors.openSystemSettings", error.to_string())
-            })?;
-        Ok(())
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-    {
-        Err(LocalizedMessage::new("errors.unsupportedPlatform"))
+    match platform::open_files_and_folders_settings() {
+        Ok(()) => Ok(()),
+        #[cfg(target_os = "linux")]
+        Err(platform::OpenSystemSettingsError::Unsupported) => {
+            Err(LocalizedMessage::new("errors.unsupportedPlatform"))
+        }
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        Err(platform::OpenSystemSettingsError::Launch(detail)) => Err(
+            LocalizedMessage::with_detail("errors.openSystemSettings", detail),
+        ),
     }
 }
 
@@ -2170,15 +2148,10 @@ fn save_preferences(path: &Path, preferences: &DesktopPreferences) -> anyhow::Re
 fn hide_to_tray(app: &AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
         let lifecycle = app.state::<Arc<LifecycleState>>();
-        let tray_available = lifecycle.tray_available();
-        #[cfg(target_os = "linux")]
-        let tray_available = tray_available && {
-            let available = linux_tray_host_available();
-            if !available {
-                lifecycle.set_tray_available(false);
-            }
-            available
-        };
+        let tray_available = lifecycle.tray_available() && platform::tray_host_available();
+        if !tray_available {
+            lifecycle.set_tray_available(false);
+        }
         if tray_available {
             let _ = window.hide();
         } else {
@@ -2186,73 +2159,12 @@ fn hide_to_tray(app: &AppHandle) {
             // Keep a taskbar entry so the user can always recover the window.
             let _ = window.minimize();
         }
-        #[cfg(target_os = "macos")]
-        if tray_available {
-            let _ = app.set_activation_policy(tauri::ActivationPolicy::Accessory);
-        }
+        platform::after_hide_to_tray(app, tray_available);
     }
-}
-
-#[cfg(target_os = "linux")]
-fn linux_tray_host_available() -> bool {
-    let Some(executable) = agentkib_platform::command::resolve("gdbus") else {
-        return false;
-    };
-    let mut command = Command::new(executable);
-    command
-        .args([
-            "call",
-            "--session",
-            "--dest",
-            "org.freedesktop.DBus",
-            "--object-path",
-            "/org/freedesktop/DBus",
-            "--method",
-            "org.freedesktop.DBus.NameHasOwner",
-            "org.kde.StatusNotifierWatcher",
-        ])
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null());
-    configure_process_group(&mut command);
-    let Ok(mut child) = command.spawn() else {
-        return false;
-    };
-    let Ok(process_tree) = ProcessTree::attach(&child) else {
-        let _ = child.kill();
-        let _ = child.wait();
-        return false;
-    };
-    let started = Instant::now();
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) if status.success() => {
-                return child
-                    .wait_with_output()
-                    .ok()
-                    .is_some_and(|output| linux_tray_watcher_response(&output.stdout));
-            }
-            Ok(Some(_)) | Err(_) => return false,
-            Ok(None) if started.elapsed() < Duration::from_secs(2) => {
-                std::thread::sleep(Duration::from_millis(25));
-            }
-            Ok(None) => {
-                let _ = process_tree.terminate();
-                let _ = child.wait();
-                return false;
-            }
-        }
-    }
-}
-
-#[cfg(any(target_os = "linux", test))]
-fn linux_tray_watcher_response(output: &[u8]) -> bool {
-    std::str::from_utf8(output).is_ok_and(|value| value.trim() == "(true,)")
 }
 
 fn show_main_window(app: &AppHandle) {
-    #[cfg(target_os = "macos")]
-    let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
+    platform::before_show_main_window(app);
     if let Some(window) = app.get_webview_window("main") {
         let _ = window.unminimize();
         let _ = window.show();
@@ -3130,7 +3042,7 @@ fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
     let tray_image = tauri::include_image!("icons/tray-icon-windows.png");
     #[cfg(not(target_os = "windows"))]
     let tray_image = tauri::include_image!("icons/tray-icon.png");
-    let mut tray = TrayIconBuilder::with_id("agentkib-status")
+    let tray = TrayIconBuilder::with_id("agentkib-status")
         .icon(tray_image)
         .menu(&menu)
         .tooltip(translate(locale, "tray.tooltip", &[]))
@@ -3157,14 +3069,13 @@ fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
                 request_guarded_exit(app);
             }
             _ => {}
-        });
+        })
+        .show_menu_on_left_click(platform::SHOW_TRAY_MENU_ON_LEFT_CLICK);
 
     #[cfg(target_os = "macos")]
-    {
+    let tray = {
         use tauri::tray::{MouseButton, MouseButtonState, TrayIconEvent};
-        tray = tray
-            .icon_as_template(true)
-            .show_menu_on_left_click(false)
+        tray.icon_as_template(true)
             .on_tray_icon_event(|tray, event| {
                 if let TrayIconEvent::Click {
                     rect,
@@ -3175,13 +3086,9 @@ fn setup_tray(app: &mut tauri::App) -> tauri::Result<()> {
                 {
                     toggle_quota_popover(tray.app_handle(), &rect);
                 }
-            });
-    }
+            })
+    };
 
-    #[cfg(not(target_os = "macos"))]
-    {
-        tray = tray.show_menu_on_left_click(true);
-    }
     tray.build(app)?;
     Ok(())
 }
@@ -3798,17 +3705,9 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             let _ = refresh_app_menu(app.handle());
             let tray_result = setup_tray(app);
-            let tray_available = tray_result.is_ok();
-            #[cfg(target_os = "linux")]
-            let tray_available = tray_available && linux_tray_host_available();
+            let tray_available = platform::resolve_tray_setup(tray_result)?;
             app.state::<Arc<LifecycleState>>()
                 .set_tray_available(tray_available);
-            #[cfg(not(target_os = "linux"))]
-            tray_result?;
-            #[cfg(target_os = "linux")]
-            if let Err(error) = tray_result {
-                eprintln!("AgentKib system tray is unavailable: {error}");
-            }
             app.state::<Arc<HubController>>().start()?;
             seed_refresh_freshness(app.handle());
             start_refresh_schedulers(app.handle().clone());
@@ -4217,12 +4116,5 @@ mod tests {
         assert!(!lifecycle.tray_available());
         lifecycle.set_tray_available(true);
         assert!(lifecycle.tray_available());
-    }
-
-    #[test]
-    fn parses_status_notifier_watcher_response_strictly() {
-        assert!(linux_tray_watcher_response(b"(true,)\n"));
-        assert!(!linux_tray_watcher_response(b"(false,)\n"));
-        assert!(!linux_tray_watcher_response(b"unexpected"));
     }
 }

--- a/apps/desktop/src-tauri/src/platform/linux.rs
+++ b/apps/desktop/src-tauri/src/platform/linux.rs
@@ -1,0 +1,94 @@
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use agentkib_platform::process::{ProcessTree, configure_process_group};
+use tauri::AppHandle;
+
+use super::OpenSystemSettingsError;
+
+pub(crate) const SHOW_TRAY_MENU_ON_LEFT_CLICK: bool = true;
+
+pub(crate) fn open_files_and_folders_settings() -> Result<(), OpenSystemSettingsError> {
+    Err(OpenSystemSettingsError::Unsupported)
+}
+
+pub(crate) fn tray_host_available() -> bool {
+    let Some(executable) = agentkib_platform::command::resolve("gdbus") else {
+        return false;
+    };
+    let mut command = Command::new(executable);
+    command
+        .args([
+            "call",
+            "--session",
+            "--dest",
+            "org.freedesktop.DBus",
+            "--object-path",
+            "/org/freedesktop/DBus",
+            "--method",
+            "org.freedesktop.DBus.NameHasOwner",
+            "org.kde.StatusNotifierWatcher",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    configure_process_group(&mut command);
+    let Ok(mut child) = command.spawn() else {
+        return false;
+    };
+    let Ok(process_tree) = ProcessTree::attach(&child) else {
+        let _ = child.kill();
+        let _ = child.wait();
+        return false;
+    };
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if status.success() => {
+                return child
+                    .wait_with_output()
+                    .ok()
+                    .is_some_and(|output| tray_watcher_response(&output.stdout));
+            }
+            Ok(Some(_)) | Err(_) => return false,
+            Ok(None) if started.elapsed() < Duration::from_secs(2) => {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Ok(None) => {
+                let _ = process_tree.terminate();
+                let _ = child.wait();
+                return false;
+            }
+        }
+    }
+}
+
+pub(crate) fn resolve_tray_setup(result: tauri::Result<()>) -> tauri::Result<bool> {
+    match result {
+        Ok(()) => Ok(tray_host_available()),
+        Err(error) => {
+            eprintln!("AgentKib system tray is unavailable: {error}");
+            Ok(false)
+        }
+    }
+}
+
+fn tray_watcher_response(output: &[u8]) -> bool {
+    std::str::from_utf8(output).is_ok_and(|value| value.trim() == "(true,)")
+}
+
+pub(crate) fn after_hide_to_tray(_app: &AppHandle, _tray_available: bool) {}
+
+pub(crate) fn before_show_main_window(_app: &AppHandle) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_status_notifier_watcher_response() {
+        assert!(tray_watcher_response(b"(true,)\n"));
+        assert!(!tray_watcher_response(b"(false,)\n"));
+        assert!(!tray_watcher_response(b"invalid"));
+    }
+}

--- a/apps/desktop/src-tauri/src/platform/macos.rs
+++ b/apps/desktop/src-tauri/src/platform/macos.rs
@@ -1,0 +1,36 @@
+use std::process::Command;
+
+use tauri::{ActivationPolicy, AppHandle};
+
+use super::OpenSystemSettingsError;
+
+pub(crate) const SHOW_TRAY_MENU_ON_LEFT_CLICK: bool = false;
+
+pub(crate) fn open_files_and_folders_settings() -> Result<(), OpenSystemSettingsError> {
+    const FILES_AND_FOLDERS_SETTINGS_URL: &str =
+        "x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders";
+    Command::new("/usr/bin/open")
+        .arg(FILES_AND_FOLDERS_SETTINGS_URL)
+        .spawn()
+        .map_err(|error| OpenSystemSettingsError::Launch(error.to_string()))?;
+    Ok(())
+}
+
+pub(crate) fn tray_host_available() -> bool {
+    true
+}
+
+pub(crate) fn resolve_tray_setup(result: tauri::Result<()>) -> tauri::Result<bool> {
+    result?;
+    Ok(true)
+}
+
+pub(crate) fn after_hide_to_tray(app: &AppHandle, tray_available: bool) {
+    if tray_available {
+        let _ = app.set_activation_policy(ActivationPolicy::Accessory);
+    }
+}
+
+pub(crate) fn before_show_main_window(app: &AppHandle) {
+    let _ = app.set_activation_policy(ActivationPolicy::Regular);
+}

--- a/apps/desktop/src-tauri/src/platform/mod.rs
+++ b/apps/desktop/src-tauri/src/platform/mod.rs
@@ -1,0 +1,27 @@
+//! Desktop-shell platform hooks.
+//!
+//! Cross-crate filesystem, command, path, and process primitives belong in
+//! `agentkib-platform`. This module is intentionally limited to Tauri window
+//! and tray behavior that differs between desktop operating systems.
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "windows")]
+mod windows;
+
+#[cfg(target_os = "linux")]
+pub(crate) use linux::*;
+#[cfg(target_os = "macos")]
+pub(crate) use macos::*;
+#[cfg(target_os = "windows")]
+pub(crate) use windows::*;
+
+#[derive(Debug)]
+pub(crate) enum OpenSystemSettingsError {
+    #[cfg(target_os = "linux")]
+    Unsupported,
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    Launch(String),
+}

--- a/apps/desktop/src-tauri/src/platform/windows.rs
+++ b/apps/desktop/src-tauri/src/platform/windows.rs
@@ -1,0 +1,34 @@
+use std::process::Command;
+
+use tauri::AppHandle;
+
+use super::OpenSystemSettingsError;
+
+pub(crate) const SHOW_TRAY_MENU_ON_LEFT_CLICK: bool = true;
+
+pub(crate) fn open_files_and_folders_settings() -> Result<(), OpenSystemSettingsError> {
+    Command::new("cmd.exe")
+        .args([
+            "/D",
+            "/C",
+            "start",
+            "",
+            "ms-settings:privacy-broadfilesystemaccess",
+        ])
+        .spawn()
+        .map_err(|error| OpenSystemSettingsError::Launch(error.to_string()))?;
+    Ok(())
+}
+
+pub(crate) fn tray_host_available() -> bool {
+    true
+}
+
+pub(crate) fn resolve_tray_setup(result: tauri::Result<()>) -> tauri::Result<bool> {
+    result?;
+    Ok(true)
+}
+
+pub(crate) fn after_hide_to_tray(_app: &AppHandle, _tray_available: bool) {}
+
+pub(crate) fn before_show_main_window(_app: &AppHandle) {}

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -1,0 +1,204 @@
+# AgentKib Windows 11 x64 构建、安装与使用指南
+
+本文对应 Windows 第一阶段目标：在 Windows 11 x64 上从源码完成环境诊断、开发启动、NSIS 打包、安装和启动。它不代表所有业务功能已经完成与 macOS 的等价验收。
+
+## AgentKib 是什么
+
+AgentKib 是一个本地优先的 Coding Agent 资产中心。它发现 Codex、Claude Code、Cursor、OpenClaw、Hermes 和 DeepSeek Harness 已使用过的工作区，并集中展示其中的 Instructions、Skills、MCP、记忆和原生配置。
+
+主要页面和功能如下：
+
+- **首页**：查看工作区、Agent、资产、额度和近期活动概况。
+- **工作区**：查看自动发现或手动添加的项目；进入项目后可查看概览、资产、有效上下文和待应用变更。
+- **资产**：按类型集中查看 Instructions、Skills、MCP、记忆及其他 Agent 配置。
+- **Agent**：查看支持的 Agent 是否已安装、配置目录和发现到的资产。
+- **额度**：展示本机能够读取到的额度窗口、余额和重置时间；数据源不可用时会明确标记。
+- **洞察**：汇总 Token、会话、Git 提交、工作区热度和成就等本地统计。
+- **设置**：管理扫描目录、关闭行为、语言、主题、MCP Hub、远程 Gateway 和 Obsidian 集成。
+
+发现和浏览不会直接修改 Agent 配置。需要同步公共资产时，AgentKib 会先生成 ChangeSet 和完整 Diff，确认后才写入。
+
+## 一、安装编译环境
+
+以下命令在 PowerShell 中执行。推荐使用与项目 CI 一致的版本。
+
+### 1. Node.js 22 和 pnpm 10.8.1
+
+```powershell
+winget install --exact --id OpenJS.NodeJS.22 --source winget --accept-package-agreements --accept-source-agreements
+```
+
+安装后重新打开 PowerShell，再执行：
+
+```powershell
+corepack enable
+corepack prepare pnpm@10.8.1 --activate
+node --version
+pnpm --version
+```
+
+预期 Node.js 主版本为 `22`，pnpm 为 `10.8.1`。
+
+如果 PowerShell 提示无法加载 `pnpm.ps1`，可只为当前 Windows 用户启用常用的本地脚本策略，然后重新打开 PowerShell：
+
+```powershell
+Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+```
+
+`RemoteSigned` 允许本地脚本运行，但从网络下载且未解除阻止的脚本仍需签名。
+
+### 2. Rust stable MSVC
+
+```powershell
+winget install --exact --id Rustlang.Rustup --source winget --accept-package-agreements --accept-source-agreements
+rustup default stable-msvc
+rustup target add x86_64-pc-windows-msvc
+rustup component add rustfmt clippy
+```
+
+验证：
+
+```powershell
+rustc -vV
+cargo --version
+```
+
+`rustc -vV` 中的 host 应为 `x86_64-pc-windows-msvc`。
+
+### 3. Visual Studio Build Tools 2022 和 Windows SDK
+
+```powershell
+winget install --exact --id Microsoft.VisualStudio.2022.BuildTools --source winget --accept-package-agreements --accept-source-agreements --override "--wait --passive --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+```
+
+该工作负载应包含 MSVC x64/x86 编译工具和 Windows 10/11 SDK。若安装器提示重启，请先重启 Windows。
+
+### 4. WebView2 Runtime
+
+Windows 11 和 Microsoft Edge 通常已包含 WebView2 Evergreen Runtime。若诊断提示缺失，请安装微软官方 WebView2 Evergreen Runtime 后重开终端。
+
+### 5. 一键诊断
+
+在仓库根目录执行：
+
+```powershell
+pnpm diagnose:windows
+```
+
+诊断为只读操作，会检查系统架构、Git/Node/pnpm/Rust、MSVC、Windows SDK、WebView2，以及 GitHub 和 Cargo Registry 连通性。存在必需项缺失时会返回非零退出码和修复提示。
+
+## 二、安装项目依赖
+
+在仓库根目录执行：
+
+```powershell
+pnpm install --frozen-lockfile
+```
+
+首次开发启动或打包时，项目还会下载并校验固定版本的 Windows 额度 Collector sidecar。
+
+## 三、开发模式启动
+
+```powershell
+pnpm dev
+```
+
+首次编译 Rust 依赖耗时会明显长于后续启动。编译完成后会打开带 Windows 原生标题栏的 AgentKib 主窗口。
+
+- 停止开发服务：回到运行命令的终端按 `Ctrl+C`。
+- 关闭主窗口：首次关闭会询问“隐藏到托盘”或“退出”；选择隐藏后会记住该行为，应用继续在后台运行。
+- 恢复窗口：单击托盘图标，或右键托盘图标选择打开应用。
+- 完全退出：在托盘菜单选择“退出”。
+
+## 四、基本使用
+
+1. 首次启动后等待自动发现完成。AgentKib 只从支持的 Agent 元数据和显式扫描目录发现工作区，不会默认扫描整块磁盘。
+2. 打开“工作区”，确认项目路径、来源、资产数量和警告；没有自动发现时，可手动添加工作区或扫描目录。
+3. 在“资产”和“Agent”中查看现有 Instructions、Skills、MCP、Hooks、Profiles 和配置。
+4. 进入工作区的“上下文”，选择 Agent 和工作目录，检查实际加载顺序、作用域、覆盖关系和潜在冲突。
+5. 需要同步公共资产时，在变更页查看完整 Diff。确认目标路径和内容后再应用；涉及 Agent Home 的写入会单独请求授权。
+6. 在“设置”中按需配置 MCP Hub、Obsidian 或 OpenClaw/Hermes Remote Gateway。这些集成默认不会自动启用。
+7. 在“额度”和“洞察”中查看本机可获得的数据。数据源缺失或不完整时，界面会显示不可用或部分覆盖，而不是推测结果。
+
+DeepSeek Harness 当前为 Beta 只读目标，不会被写入或配置 MCP。
+
+## 五、构建 NSIS 安装包
+
+```powershell
+pnpm tauri build --bundles nsis
+```
+
+构建成功后，安装包位于：
+
+```text
+target\release\bundle\nsis\*.exe
+```
+
+双击安装包，完成后可从 Windows 开始菜单搜索并打开 **AgentKib**。当前内部测试包未做代码签名，Windows SmartScreen 可能显示未知发布者；请确认文件确实来自自己的本机构建后再选择继续。
+
+## 六、本地数据位置
+
+应用数据默认存放在：
+
+```text
+%LOCALAPPDATA%\com.agentkib.desktop
+```
+
+其中包含 SQLite 数据库、MCP 包和本机设置。卸载前如需保留数据，请备份该目录。不要把这个目录、`node_modules`、`target` 或安装包提交到 Git。
+
+## 七、常见问题
+
+### 浏览器能打开 GitHub，但 Git 无法 clone
+
+先检查 Git 是否仍指向已经变化的 Clash 端口：
+
+```powershell
+git config --global --get-urlmatch http.proxy https://github.com/starroyhq/agentkib.git
+Get-NetTCPConnection -State Listen | Where-Object LocalAddress -eq "127.0.0.1"
+```
+
+确认 Clash 当前 HTTP/Mixed 端口后，只给 GitHub 更新代理，例如：
+
+```powershell
+git config --global http.https://github.com.proxy http://127.0.0.1:7897
+git ls-remote https://github.com/starroyhq/agentkib.git refs/heads/main
+```
+
+端口 `7897` 只是示例，必须以本机 Clash 实际配置为准。
+
+### Cargo 或 sidecar 下载失败
+
+只在当前构建会话设置代理，不要把本机端口写进仓库：
+
+```powershell
+$env:HTTP_PROXY = "http://127.0.0.1:7897"
+$env:HTTPS_PROXY = "http://127.0.0.1:7897"
+pnpm dev
+```
+
+### 找不到 `link.exe`、MSVC 或 Windows SDK
+
+重新打开 Visual Studio Installer，确认 Build Tools 2022 已安装“使用 C++ 的桌面开发”，并包含 MSVC x64/x86 与 Windows 10/11 SDK；安装完成后重开终端，必要时重启 Windows。
+
+### 窗口空白或 WebView2 报错
+
+修复或重新安装 WebView2 Evergreen Runtime，然后删除开发构建缓存并重新编译。不要删除 `%LOCALAPPDATA%\com.agentkib.desktop`，除非已经备份并确定要清空应用数据。
+
+### `localhost:1420` 端口被占用
+
+开发服务器默认使用端口 `1420`。先结束占用该端口的旧 Vite/Node 进程，再重新运行 `pnpm dev`。
+
+```powershell
+Get-NetTCPConnection -LocalPort 1420 -ErrorAction SilentlyContinue
+```
+
+### SmartScreen 阻止安装
+
+第一阶段安装包未签名，可能触发 SmartScreen。只对自己刚构建且路径、时间和文件名均确认无误的安装包选择“更多信息”并继续；正式分发前应增加代码签名。
+
+## 当前阶段限制
+
+- 已验收目标仅为 Windows 11 x64 的编译、开发启动、NSIS 安装和启动。
+- Windows ARM64、代码签名、自动更新和正式发布不在本阶段范围内。
+- macOS/Linux 行为通过平台隔离和现有 CI 保持，本机无法替代对应平台的原生回归。
+- 完整 Windows 功能等价测试仍需后续阶段逐项完成。

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.8.1",
   "scripts": {
+    "diagnose:windows": "powershell -NoProfile -ExecutionPolicy Bypass -File apps/desktop/scripts/diagnose-windows.ps1",
     "dev": "pnpm --filter @agentkib/desktop dev",
     "build": "pnpm --filter @agentkib/desktop build",
     "test": "pnpm --filter @agentkib/desktop test",


### PR DESCRIPTION
## 变更内容

- 新增跨平台 `platform` 模块，将 macOS、Windows 和 Linux 的平台行为隔离。
- 完成 Windows 托盘、窗口恢复及相关桌面行为的第一阶段适配。
- 新增 `diagnose:windows` 环境诊断脚本。
- 新增 Windows 11 x64 构建、开发启动、NSIS 打包和安装说明。
- 在 README 中补充 Windows 指南入口。

## 本阶段范围

仅覆盖 Windows 11 x64 可编译、可开发启动、可构建和可安装所需的第一阶段适配，不扩展为完整 Windows 功能等价重构。

## 验证结果

- `pnpm install --frozen-lockfile`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm test`（122 passed，1 skipped）
- `pnpm typecheck`
- `pnpm build`