### PR TITLE
fix(windows): 修复应用启动及工作区切换时的控制台闪窗

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -40,9 +40,7 @@ use agentkib_platform::applications::{
     open_workspace as open_workspace_application,
 };
 #[cfg(any(target_os = "linux", target_os = "windows"))]
-use agentkib_platform::process::ProcessTree;
-#[cfg(target_os = "linux")]
-use agentkib_platform::process::configure_process_group;
+use agentkib_platform::process::{ProcessTree, configure_process_group};
 use agentkib_platform::{fs::atomic_write, path as platform_path};
 #[cfg(target_os = "windows")]
 use agentkib_quota::resolve_win_codexbar_config;
@@ -2470,6 +2468,7 @@ impl QuotaCommandRunner for WindowsQuotaRunner {
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        configure_process_group(&mut command);
         let mut child = command.spawn()?;
         let process_tree = ProcessTree::attach(&child).inspect_err(|_| {
             let _ = child.kill();

--- a/apps/desktop/src-tauri/src/platform/windows.rs
+++ b/apps/desktop/src-tauri/src/platform/windows.rs
@@ -1,5 +1,6 @@
 use std::process::Command;
 
+use agentkib_platform::process::configure_process_group;
 use tauri::AppHandle;
 
 use super::OpenSystemSettingsError;
@@ -7,14 +8,16 @@ use super::OpenSystemSettingsError;
 pub(crate) const SHOW_TRAY_MENU_ON_LEFT_CLICK: bool = true;
 
 pub(crate) fn open_files_and_folders_settings() -> Result<(), OpenSystemSettingsError> {
-    Command::new("cmd.exe")
-        .args([
-            "/D",
-            "/C",
-            "start",
-            "",
-            "ms-settings:privacy-broadfilesystemaccess",
-        ])
+    let mut command = Command::new("cmd.exe");
+    command.args([
+        "/D",
+        "/C",
+        "start",
+        "",
+        "ms-settings:privacy-broadfilesystemaccess",
+    ]);
+    configure_process_group(&mut command);
+    command
         .spawn()
         .map_err(|error| OpenSystemSettingsError::Launch(error.to_string()))?;
     Ok(())

--- a/crates/agentkib-platform/src/applications.rs
+++ b/crates/agentkib-platform/src/applications.rs
@@ -315,12 +315,13 @@ fn windows_app_path(executable_name: &str) -> Option<PathBuf> {
     ];
     ROOTS.into_iter().find_map(|root| {
         let key = format!(r"{root}\{executable_name}");
-        let output = Command::new("reg.exe")
+        let mut command = Command::new("reg.exe");
+        command
             .args(["query", &key, "/ve"])
             .stdin(Stdio::null())
-            .stderr(Stdio::null())
-            .output()
-            .ok()?;
+            .stderr(Stdio::null());
+        crate::process::configure_process_group(&mut command);
+        let output = command.output().ok()?;
         if !output.status.success() {
             return None;
         }

--- a/crates/agentkib-platform/src/process.rs
+++ b/crates/agentkib-platform/src/process.rs
@@ -1,16 +1,24 @@
 use std::io;
 use std::process::{Child, Command};
 
-/// Configure a command so the spawned child becomes the leader of a new Unix
-/// process group. Call this before `spawn`, then attach a [`ProcessTree`] to
-/// ensure timeouts terminate descendants as well as the direct child.
+/// Configure a background command before spawning it.
+///
+/// Unix children become process-group leaders so timeouts can terminate their
+/// descendants. Windows children run without creating a visible console; their
+/// descendants are supervised through a [`ProcessTree`] job object.
 pub fn configure_process_group(command: &mut Command) {
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
         command.process_group(0);
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = command;
     }


### PR DESCRIPTION
## 问题

- Windows 上启动 AgentKib 时会出现额外的 CMD 黑框。
- 进入工作区并选择项目时，控制台窗口会连续闪烁多次。

## 修复内容

- 为 Windows 后台子进程统一配置 `CREATE_NO_WINDOW`。
- 隐藏应用启动时 quota sidecar 的控制台窗口。
- 隐藏工作区应用探测过程中 `reg.exe` 产生的频繁闪窗。
- 避免打开 Windows 系统设置时出现额外控制台窗口。

## 验证结果

- `cargo fmt --all --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm tauri build --bundles nsis`
- 实际验证应用启动时不再出现黑框。
- 实际验证进入工作区并选择项目时不再出现控制台频闪。