### PR TITLE
ci(desktop): 添加手动多平台桌面打包流程

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,4 +1,4 @@
-name: Linux
+name: Linux Checks
 
 on:
   pull_request:
@@ -14,7 +14,7 @@ env:
 
 jobs:
   ubuntu-x64:
-    name: Ubuntu 22.04 x64 (deb and AppImage)
+    name: Check Ubuntu 22.04 x64
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -56,14 +56,14 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Diagnose build environment
-        run: apps/desktop/scripts/diagnose-linux.sh --strict --packaging deb
+        run: apps/desktop/scripts/diagnose-linux.sh --strict
 
-      - name: Run release checks and build packages
+      - name: Run Ubuntu x64 checks
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          log=artifacts/linux-ubuntu22-x64-build.log
+          log=artifacts/linux-ubuntu22-x64-checks.log
           run_logged() {
             printf '\n## %s\n' "$*" | tee -a "$log"
             "$@" 2>&1 | tee -a "$log"
@@ -74,40 +74,17 @@ jobs:
           run_logged pnpm test
           run_logged pnpm typecheck
           run_logged pnpm build
-          rm -rf target/release/bundle
-          run_logged apps/desktop/scripts/build-linux-bundles.sh --bundles deb,appimage
 
-      - name: Verify packages and write checksums
-        run: |
-          .github/scripts/smoke-test-linux-package.sh target deb
-          .github/scripts/smoke-test-linux-package.sh target appimage
-          .github/scripts/write-linux-checksums.sh target
-          package=$(find "$PWD/target" -type f -name '*.deb' -print -quit)
-          sudo apt-get install -y "$package"
-          .github/scripts/smoke-test-linux-installed.sh
-
-      - name: Upload Ubuntu x64 packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: agentkib-linux-ubuntu-x64
-          if-no-files-found: error
-          path: |
-            target/**/bundle/deb/*.deb
-            target/**/bundle/deb/*.sha256
-            target/**/bundle/appimage/*.AppImage
-            target/**/bundle/appimage/*.sha256
-
-      - name: Upload Ubuntu x64 build log
+      - name: Upload Ubuntu x64 check log
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: agentkib-linux-ubuntu-x64-log
           if-no-files-found: warn
-          path: |
-            artifacts/linux-ubuntu22-x64-build.log
+          path: artifacts/linux-ubuntu22-x64-checks.log
 
   ubuntu-arm64:
-    name: Ubuntu 24.04 ARM64 preview (deb and AppImage)
+    name: Check Ubuntu 24.04 ARM64 preview
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -149,14 +126,14 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Diagnose build environment
-        run: apps/desktop/scripts/diagnose-linux.sh --strict --packaging deb
+        run: apps/desktop/scripts/diagnose-linux.sh --strict
 
-      - name: Run ARM64 checks and build packages
+      - name: Run Ubuntu ARM64 checks
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          log=artifacts/linux-ubuntu24-arm64-build.log
+          log=artifacts/linux-ubuntu24-arm64-checks.log
           run_logged() {
             printf '\n## %s\n' "$*" | tee -a "$log"
             "$@" 2>&1 | tee -a "$log"
@@ -165,40 +142,17 @@ jobs:
           run_logged cargo clippy --workspace --all-targets -- -D warnings
           run_logged pnpm test
           run_logged pnpm typecheck
-          rm -rf target/release/bundle
-          run_logged apps/desktop/scripts/build-linux-bundles.sh --bundles deb,appimage
 
-      - name: Verify packages and write checksums
-        run: |
-          .github/scripts/smoke-test-linux-package.sh target deb
-          .github/scripts/smoke-test-linux-package.sh target appimage
-          .github/scripts/write-linux-checksums.sh target
-          package=$(find "$PWD/target" -type f -name '*.deb' -print -quit)
-          sudo apt-get install -y "$package"
-          .github/scripts/smoke-test-linux-installed.sh
-
-      - name: Upload Ubuntu ARM64 preview packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: agentkib-linux-ubuntu-arm64-preview
-          if-no-files-found: error
-          path: |
-            target/**/bundle/deb/*.deb
-            target/**/bundle/deb/*.sha256
-            target/**/bundle/appimage/*.AppImage
-            target/**/bundle/appimage/*.sha256
-
-      - name: Upload Ubuntu ARM64 build log
+      - name: Upload Ubuntu ARM64 check log
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: agentkib-linux-ubuntu-arm64-preview-log
           if-no-files-found: warn
-          path: |
-            artifacts/linux-ubuntu24-arm64-build.log
+          path: artifacts/linux-ubuntu24-arm64-checks.log
 
   fedora-x64:
-    name: Fedora x64 (RPM)
+    name: Check Fedora x64
     runs-on: ubuntu-24.04
     container: fedora:42
     steps:
@@ -241,14 +195,14 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Diagnose build environment
-        run: apps/desktop/scripts/diagnose-linux.sh --strict --packaging rpm
+        run: apps/desktop/scripts/diagnose-linux.sh --strict
 
-      - name: Run Fedora checks and build RPM
+      - name: Run Fedora checks
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          log=artifacts/linux-fedora42-x64-build.log
+          log=artifacts/linux-fedora42-x64-checks.log
           run_logged() {
             printf '\n## %s\n' "$*" | tee -a "$log"
             "$@" 2>&1 | tee -a "$log"
@@ -258,31 +212,11 @@ jobs:
           run_logged pnpm test
           run_logged pnpm typecheck
           run_logged pnpm build
-          rm -rf target/release/bundle
-          run_logged apps/desktop/scripts/build-linux-bundles.sh --bundles rpm
 
-      - name: Verify RPM and write checksum
-        run: |
-          .github/scripts/smoke-test-linux-package.sh target rpm
-          .github/scripts/write-linux-checksums.sh target
-          package=$(find target -type f -name '*.rpm' -print -quit)
-          dnf install -y "$package"
-          .github/scripts/smoke-test-linux-installed.sh
-
-      - name: Upload Fedora x64 package
-        uses: actions/upload-artifact@v4
-        with:
-          name: agentkib-linux-fedora-x64
-          if-no-files-found: error
-          path: |
-            target/**/bundle/rpm/*.rpm
-            target/**/bundle/rpm/*.sha256
-
-      - name: Upload Fedora x64 build log
+      - name: Upload Fedora x64 check log
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: agentkib-linux-fedora-x64-log
           if-no-files-found: warn
-          path: |
-            artifacts/linux-fedora42-x64-build.log
+          path: artifacts/linux-fedora42-x64-checks.log

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,25 +1,113 @@
-name: Desktop Release Artifacts
+name: Desktop Package Artifacts
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
-    inputs:
-      tag:
-        description: Existing release tag to attach desktop artifacts to
-        required: true
-        type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: desktop-release-${{ github.event.release.tag_name || inputs.tag || github.ref_name }}
+  group: desktop-packages-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
+  preflight:
+    name: Validate and test selected revision
+    runs-on: ubuntu-22.04
+    outputs:
+      app_version: ${{ steps.version.outputs.app_version }}
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout selected revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Install Linux desktop dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config libssl-dev \
+            libgtk-3-dev libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev librsvg2-dev libxdo-dev
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: package-preflight-ubuntu22-x64
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate desktop versions
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          tauri_version=$(node -p "JSON.parse(require('fs').readFileSync('apps/desktop/src-tauri/tauri.conf.json')).version")
+          package_version=$(node -p "JSON.parse(require('fs').readFileSync('apps/desktop/package.json')).version")
+          cargo_version=$(cargo metadata --no-deps --format-version 1 | node -e '
+            let input = "";
+            process.stdin.setEncoding("utf8");
+            process.stdin.on("data", (chunk) => input += chunk);
+            process.stdin.on("end", () => {
+              const desktop = JSON.parse(input).packages.find(({ name }) => name === "agentkib-desktop");
+              if (!desktop) process.exit(1);
+              console.log(desktop.version);
+            });
+          ')
+
+          if [[ ! "$tauri_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid desktop version: $tauri_version" >&2
+            exit 1
+          fi
+          if [[ "$tauri_version" != "$package_version" || "$tauri_version" != "$cargo_version" ]]; then
+            echo "Desktop versions differ: tauri=$tauri_version package=$package_version cargo=$cargo_version" >&2
+            exit 1
+          fi
+
+          echo "Validated AgentKib desktop version $tauri_version"
+          echo "app_version=$tauri_version" >> "$GITHUB_OUTPUT"
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Test Rust workspace
+        run: cargo test --workspace
+
+      - name: Lint Rust workspace
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Test frontend
+        run: pnpm test
+
+      - name: Typecheck frontend
+        run: pnpm typecheck
+
+      - name: Build frontend
+        run: pnpm build
+
   desktop:
     name: Build ${{ matrix.name }} ${{ matrix.arch }}
+    needs: preflight
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -63,13 +151,15 @@ jobs:
             bundles: deb,appimage
 
     env:
+      APP_VERSION: ${{ needs.preflight.outputs.app_version }}
       CARGO_TERM_COLOR: always
       DESKTOP_RELEASE_DIR: dist/desktop-release
-      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag || github.ref_name }}
 
     steps:
-      - name: Checkout
+      - name: Checkout selected revision
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
 
       - name: Install Linux desktop dependencies
         if: runner.os == 'Linux'
@@ -80,7 +170,8 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             build-essential binutils curl file pkg-config patchelf libssl-dev \
             libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
-            librsvg2-dev libxdo-dev libfuse2 libglib2.0-bin desktop-file-utils xdg-utils
+            librsvg2-dev libxdo-dev libfuse2 libglib2.0-bin desktop-file-utils \
+            xdg-utils dbus-x11 xvfb
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -106,12 +197,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Read application version
-        shell: bash
-        run: |
-          version=$(node -p "JSON.parse(require('fs').readFileSync('apps/desktop/src-tauri/tauri.conf.json')).version")
-          echo "APP_VERSION=$version" >> "$GITHUB_ENV"
-
       - name: Clean previous bundle outputs
         shell: bash
         run: find target -type d -path '*/release/bundle' -prune -exec rm -rf '{}' + 2>/dev/null || true
@@ -127,6 +212,32 @@ jobs:
       - name: Smoke test Linux bundles
         if: runner.os == 'Linux'
         run: .github/scripts/smoke-test-linux-package.sh target
+
+      - name: Smoke test installed Ubuntu package
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          package=$(find "$PWD/target" -type f -name '*.deb' -path '*/bundle/deb/*' -print -quit)
+          test -n "$package"
+          sudo apt-get install -y "$package"
+          .github/scripts/smoke-test-linux-installed.sh
+
+      - name: Smoke test Windows x64 installer
+        if: runner.os == 'Windows' && matrix.arch == 'x64'
+        shell: pwsh
+        run: ./.github/scripts/smoke-test-windows-installer.ps1 -SearchRoot target
+
+      - name: Verify macOS application bundle
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          app=$(find target -type d -path '*/bundle/macos/*.app' -print -quit)
+          test -n "$app"
+          executable=$(find "$app/Contents/MacOS" -maxdepth 1 -type f -perm -u+x -print -quit)
+          test -n "$executable"
+          echo "Verified macOS application executable: $executable"
 
       - name: Stage release artifacts
         shell: bash
@@ -178,21 +289,15 @@ jobs:
           path: ${{ env.DESKTOP_RELEASE_DIR }}/*
           if-no-files-found: error
 
-      - name: Upload artifacts to GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ env.RELEASE_TAG }}
-          files: ${{ env.DESKTOP_RELEASE_DIR }}/*
-          fail_on_unmatched_files: true
-
   fedora-x64:
     name: Build Fedora x64 RPM
+    needs: preflight
     runs-on: ubuntu-24.04
     container: fedora:42
     env:
+      APP_VERSION: ${{ needs.preflight.outputs.app_version }}
       CARGO_TERM_COLOR: always
       DESKTOP_RELEASE_DIR: dist/desktop-release
-      RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag || github.ref_name }}
 
     steps:
       - name: Install Fedora build dependencies
@@ -201,10 +306,13 @@ jobs:
             git curl tar gzip xz file findutils which binutils \
             gcc gcc-c++ make openssl-devel pkgconf-pkg-config patchelf \
             gtk3-devel webkit2gtk4.1-devel libappindicator-gtk3-devel \
-            librsvg2-devel libxdo-devel rpm-build rpmdevtools cpio desktop-file-utils xdg-utils
+            librsvg2-devel libxdo-devel rpm-build rpmdevtools cpio \
+            desktop-file-utils xdg-utils dbus-daemon xorg-x11-server-Xvfb util-linux
 
-      - name: Checkout
+      - name: Checkout selected revision
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -230,12 +338,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Read application version
-        shell: bash
-        run: |
-          version=$(node -p "JSON.parse(require('fs').readFileSync('apps/desktop/src-tauri/tauri.conf.json')).version")
-          echo "APP_VERSION=$version" >> "$GITHUB_ENV"
-
       - name: Clean previous bundle outputs
         shell: bash
         run: find target -type d -path '*/release/bundle' -prune -exec rm -rf '{}' + 2>/dev/null || true
@@ -245,6 +347,15 @@ jobs:
 
       - name: Smoke test RPM
         run: .github/scripts/smoke-test-linux-package.sh target rpm
+
+      - name: Smoke test installed RPM
+        shell: bash
+        run: |
+          set -euo pipefail
+          package=$(find target -type f -name '*.rpm' -path '*/bundle/rpm/*' -print -quit)
+          test -n "$package"
+          dnf install -y "$package"
+          .github/scripts/smoke-test-linux-installed.sh
 
       - name: Stage release artifact and checksum
         shell: bash
@@ -264,10 +375,3 @@ jobs:
           name: agentkib-desktop-linux-fedora-x64
           path: ${{ env.DESKTOP_RELEASE_DIR }}/*
           if-no-files-found: error
-
-      - name: Upload artifacts to GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ env.RELEASE_TAG }}
-          files: ${{ env.DESKTOP_RELEASE_DIR }}/*
-          fail_on_unmatched_files: true

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -75,7 +75,7 @@ jobs:
             });
           ')
 
-          if [[ ! "$tauri_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+          if [[ ! "$tauri_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
             echo "Invalid desktop version: $tauri_version" >&2
             exit 1
           fi

--- a/.github/workflows/windows-x64.yml
+++ b/.github/workflows/windows-x64.yml
@@ -1,4 +1,4 @@
-name: Windows x64
+name: Windows Checks
 
 on:
   pull_request:
@@ -29,7 +29,7 @@ jobs:
         run: cargo check --workspace --all-targets
 
   build:
-    name: Test and build NSIS
+    name: Test Windows x64
     runs-on: windows-2022
     env:
       CARGO_TERM_COLOR: always
@@ -56,11 +56,11 @@ jobs:
         shell: pwsh
         run: pnpm install --frozen-lockfile
 
-      - name: Run release checks and build NSIS
+      - name: Run Windows checks
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path artifacts | Out-Null
-          $log = "artifacts/windows-x64-build.log"
+          $log = "artifacts/windows-x64-checks.log"
           $ErrorActionPreference = "Stop"
 
           function Invoke-LoggedCommand {
@@ -78,23 +78,11 @@ jobs:
           Invoke-LoggedCommand "pnpm test" { pnpm test }
           Invoke-LoggedCommand "pnpm typecheck" { pnpm typecheck }
           Invoke-LoggedCommand "pnpm build" { pnpm build }
-          Invoke-LoggedCommand "pnpm tauri build --bundles nsis" { pnpm tauri build --bundles nsis }
 
-      - name: Write installer checksums
-        shell: pwsh
-        run: ./.github/scripts/write-windows-checksums.ps1 -SearchRoot target
-
-      - name: Smoke test install, overwrite and uninstall
-        shell: pwsh
-        run: ./.github/scripts/smoke-test-windows-installer.ps1 -SearchRoot target
-
-      - name: Upload Windows x64 artifacts
+      - name: Upload Windows x64 check log
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: agentkib-windows-x64
+          name: agentkib-windows-x64-log
           if-no-files-found: warn
-          path: |
-            target/**/bundle/nsis/*.exe
-            target/**/bundle/nsis/*.sha256
-            artifacts/windows-x64-build.log
+          path: artifacts/windows-x64-checks.log

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ apps/desktop/scripts/build-linux-bundles.sh
 
 Build output is written to `target/release/bundle/`. Third-party licenses are listed in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
 
+Maintainers can generate unsigned multi-platform preview packages with the manually triggered GitHub Actions workflow described in [docs/RELEASE.md](docs/RELEASE.md). Pull requests and pushes run platform checks without producing installers.
+
 ### Validate
 
 ```bash

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,50 @@
+# Desktop package workflow
+
+AgentKib desktop packages are generated only by the manually triggered
+`Desktop Package Artifacts` GitHub Actions workflow. Pull requests and pushes
+run platform checks, but they do not create installers.
+
+## Build packages
+
+1. Open **Actions** in the GitHub repository.
+2. Select **Desktop Package Artifacts**.
+3. Choose **Run workflow** and select the branch to build. To build a tag, run
+   `gh workflow run release-desktop.yml --ref <tag>` instead.
+4. Wait for the preflight and every platform job to pass.
+5. Download the artifact for the target platform from the completed run.
+
+The workflow locks every job to the selected revision's commit. Before
+packaging, it verifies that the versions in the Tauri configuration, desktop
+package, and Cargo workspace match, then runs the full Rust and frontend check
+suite.
+
+## Artifacts
+
+- `agentkib-desktop-macos-arm64`: zipped `.app`, DMG, and checksums.
+- `agentkib-desktop-macos-x64`: zipped `.app`, DMG, and checksums.
+- `agentkib-desktop-windows-x64`: NSIS installer and checksum.
+- `agentkib-desktop-windows-arm64-preview`: preview NSIS installer and checksum.
+- `agentkib-desktop-linux-ubuntu-x64`: Deb, AppImage, and checksums.
+- `agentkib-desktop-linux-ubuntu-arm64-preview`: preview Deb, AppImage, and checksums.
+- `agentkib-desktop-linux-fedora-x64`: RPM and checksum.
+
+Each checksum file is named after its package with the `.sha256` suffix. Verify
+the downloaded package before installing it, for example:
+
+```bash
+shasum -a 256 -c AgentKib_0.1.0_macos-arm64.dmg.sha256
+```
+
+On Linux, use `sha256sum -c`. On Windows, compare the value in the checksum
+file with `Get-FileHash <installer> -Algorithm SHA256`.
+
+## Preview limitations
+
+These workflow artifacts are unsigned development previews. They are not
+attached to a GitHub Release and do not include macOS notarization, Windows
+code signing, MSI packages, a macOS universal binary, or automatic updates.
+macOS Gatekeeper and Windows SmartScreen may therefore display warnings.
+
+Before sharing a build, confirm that all platform jobs passed and test the
+downloaded package on the intended operating system. ARM64 packages remain
+preview-only until they have been verified on representative hardware.


### PR DESCRIPTION
## 变更内容

- 将 Windows/Linux PR 流程收敛为平台测试与编译检查，不再生成安装包
- 将桌面打包改为唯一的手动 Actions 工作流，并锁定所选 revision 的 commit
- 增加桌面版本一致性门禁、跨平台 smoke test、校验和与打包操作说明
- 打包产物仅保存为 Actions artifacts，不创建或修改 GitHub Release

## 原因

此前 Windows 和 Linux 工作流会在每个 PR 上执行完整安装包构建，成本较高；Release 工作流也会由已发布的 Release 自动触发并由多个平台并行写入附件，容易出现部分产物状态。本次将检查与打包职责拆开，让安装包只在维护者明确手动触发时生成。

## 验证

- `cargo fmt --all -- --check`
- 使用全新 `CARGO_TARGET_DIR` 运行 `cargo test --workspace`
- 使用全新 `CARGO_TARGET_DIR` 运行 `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm test`（123 passed，1 skipped）
- `pnpm typecheck`
- `pnpm build`
- YAML 语法检查
- 版本一致性与版本漂移拒绝检查
- `git diff --check`

真实 hosted runner 的安装包构建需要合并前手动运行一次 `Desktop Package Artifacts` 验证。
