### PR TITLE
fix: 修复 Git Diff 竞态并精简跨平台检查

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
   quality:
     name: Test, lint and build
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,6 +57,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Diagnose Linux build environment
+        run: apps/desktop/scripts/diagnose-linux.sh --strict
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,83 +9,18 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: linux-checks-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  ubuntu-x64:
-    name: Check Ubuntu 22.04 x64
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Linux build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            build-essential binutils curl file git pkg-config patchelf libssl-dev \
-            libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev \
-            librsvg2-dev libxdo-dev libfuse2 libglib2.0-bin \
-            desktop-file-utils xdg-utils dbus-x11 xvfb
-
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-
-      - name: Cache Rust and verified quota collector
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cache/agentkib/codexbar/0.49.5
-          key: linux-ubuntu22-x64-${{ hashFiles('Cargo.lock', 'pnpm-lock.yaml', 'apps/desktop/scripts/prepare-quota-sidecar.mjs') }}
-          restore-keys: linux-ubuntu22-x64-
-
-      - name: Install frontend dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Diagnose build environment
-        run: apps/desktop/scripts/diagnose-linux.sh --strict
-
-      - name: Run Ubuntu x64 checks
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p artifacts
-          log=artifacts/linux-ubuntu22-x64-checks.log
-          run_logged() {
-            printf '\n## %s\n' "$*" | tee -a "$log"
-            "$@" 2>&1 | tee -a "$log"
-          }
-          run_logged cargo fmt --check
-          run_logged cargo test --workspace
-          run_logged cargo clippy --workspace --all-targets -- -D warnings
-          run_logged pnpm test
-          run_logged pnpm typecheck
-          run_logged pnpm build
-
-      - name: Upload Ubuntu x64 check log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: agentkib-linux-ubuntu-x64-log
-          if-no-files-found: warn
-          path: artifacts/linux-ubuntu22-x64-checks.log
-
   ubuntu-arm64:
     name: Check Ubuntu 24.04 ARM64 preview
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
 
@@ -105,25 +40,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 
-      - name: Cache Rust and verified quota collector
-        uses: actions/cache@v4
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cache/agentkib/codexbar/0.49.5
-          key: linux-ubuntu24-arm64-${{ hashFiles('Cargo.lock', 'pnpm-lock.yaml', 'apps/desktop/scripts/prepare-quota-sidecar.mjs') }}
-          restore-keys: linux-ubuntu24-arm64-
-
-      - name: Install frontend dependencies
-        run: pnpm install --frozen-lockfile
+          shared-key: linux-ubuntu24-arm64-checks
 
       - name: Diagnose build environment
         run: apps/desktop/scripts/diagnose-linux.sh --strict
@@ -140,21 +65,21 @@ jobs:
           }
           run_logged cargo test --workspace
           run_logged cargo clippy --workspace --all-targets -- -D warnings
-          run_logged pnpm test
-          run_logged pnpm typecheck
 
       - name: Upload Ubuntu ARM64 check log
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: agentkib-linux-ubuntu-arm64-preview-log
           if-no-files-found: warn
           path: artifacts/linux-ubuntu24-arm64-checks.log
+          retention-days: 7
 
   fedora-x64:
     name: Check Fedora x64
     runs-on: ubuntu-24.04
     container: fedora:42
+    timeout-minutes: 25
     steps:
       - name: Install Fedora build dependencies
         run: |
@@ -174,25 +99,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
 
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
 
-      - name: Cache Rust and verified quota collector
-        uses: actions/cache@v4
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cache/agentkib/codexbar/0.49.5
-          key: linux-fedora42-x64-${{ hashFiles('Cargo.lock', 'pnpm-lock.yaml', 'apps/desktop/scripts/prepare-quota-sidecar.mjs') }}
-          restore-keys: linux-fedora42-x64-
-
-      - name: Install frontend dependencies
-        run: pnpm install --frozen-lockfile
+          shared-key: linux-fedora42-x64-checks
 
       - name: Diagnose build environment
         run: apps/desktop/scripts/diagnose-linux.sh --strict
@@ -208,15 +121,12 @@ jobs:
             "$@" 2>&1 | tee -a "$log"
           }
           run_logged cargo test --workspace
-          run_logged cargo clippy --workspace --all-targets -- -D warnings
-          run_logged pnpm test
-          run_logged pnpm typecheck
-          run_logged pnpm build
 
       - name: Upload Fedora x64 check log
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: agentkib-linux-fedora-x64-log
           if-no-files-found: warn
           path: artifacts/linux-fedora42-x64-checks.log
+          retention-days: 7

--- a/.github/workflows/windows-x64.yml
+++ b/.github/workflows/windows-x64.yml
@@ -9,10 +9,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: windows-checks-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   arm64-compile:
     name: Check Windows ARM64 preview
     runs-on: windows-2022
+    timeout-minutes: 20
     env:
       CARGO_BUILD_TARGET: aarch64-pc-windows-msvc
       CARGO_TERM_COLOR: always
@@ -24,6 +29,11 @@ jobs:
         with:
           targets: aarch64-pc-windows-msvc
 
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: windows-arm64-checks
+
       - name: Check workspace for ARM64
         shell: pwsh
         run: cargo check --workspace --all-targets
@@ -31,30 +41,22 @@ jobs:
   build:
     name: Test Windows x64
     runs-on: windows-2022
+    timeout-minutes: 30
     env:
       CARGO_TERM_COLOR: always
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
       - name: Install Rust MSVC toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc
-          components: rustfmt, clippy
+          components: clippy
 
-      - name: Install frontend dependencies
-        shell: pwsh
-        run: pnpm install --frozen-lockfile
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: windows-x64-checks
 
       - name: Run Windows checks
         shell: pwsh
@@ -72,17 +74,14 @@ jobs:
             }
           }
 
-          Invoke-LoggedCommand "cargo fmt --check" { cargo fmt --check }
           Invoke-LoggedCommand "cargo test --workspace" { cargo test --workspace }
           Invoke-LoggedCommand "cargo clippy --workspace --all-targets -- -D warnings" { cargo clippy --workspace --all-targets -- -D warnings }
-          Invoke-LoggedCommand "pnpm test" { pnpm test }
-          Invoke-LoggedCommand "pnpm typecheck" { pnpm typecheck }
-          Invoke-LoggedCommand "pnpm build" { pnpm build }
 
       - name: Upload Windows x64 check log
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: agentkib-windows-x64-log
           if-no-files-found: warn
           path: artifacts/windows-x64-checks.log
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ AgentKib 会区分“已安装”和“只发现了卸载后的本地数据”�
 | 平台 | 状态 |
 | --- | --- |
 | macOS 13+（Apple Silicon / Intel） | 主要开发与验收平台 |
-| Windows 11 x64 | CI 构建 NSIS，并执行安装、覆盖安装和卸载烟测 |
-| Ubuntu 22.04 x64 | CI 构建并验证 `.deb` 与 AppImage |
-| Fedora x64 | CI 构建并验证 `.rpm` |
-| Windows ARM64 / Linux ARM64 | Preview；保证核心编译或原生打包，部分额度能力可能不可用 |
+| Windows 11 x64 | PR 验证 Rust 平台代码；手动工作流构建并烟测 NSIS |
+| Ubuntu 22.04 x64 | 核心 CI 平台；手动工作流构建并验证 `.deb` 与 AppImage |
+| Fedora x64 | PR 验证 Rust 平台代码；手动工作流构建并验证 `.rpm` |
+| Windows ARM64 / Linux ARM64 | Preview；PR 验证核心编译或测试，手动工作流生成预览包 |
 
 Windows 11 x64 的完整环境安装、开发启动、NSIS 打包和使用步骤见 [Windows 构建、安装与使用指南](docs/WINDOWS.md)。
 

--- a/apps/desktop/src/components/WorkspaceGitPage.test.tsx
+++ b/apps/desktop/src/components/WorkspaceGitPage.test.tsx
@@ -69,6 +69,15 @@ describe("layoutCommitGraph", () => {
 });
 
 describe("WorkspaceGitPage Diff", () => {
+  it("does not reload unchanged filters after the initial debounce window", async () => {
+    render(<WorkspaceGitPage workspace={workspace} />);
+
+    await waitFor(() => expect(api.workspaceGitSummary).toHaveBeenCalledTimes(1));
+    await new Promise((resolve) => window.setTimeout(resolve, 350));
+
+    expect(api.workspaceGitSummary).toHaveBeenCalledTimes(1);
+  });
+
   it("loads the complete commit Diff by default and switches to a file Diff", async () => {
     vi.mocked(api.gitDiff).mockImplementation(async (_workspaceId, request) => request.path
       ? { ...fullDiff, patch: `single:${request.path}` }

--- a/apps/desktop/src/components/WorkspaceGitPage.tsx
+++ b/apps/desktop/src/components/WorkspaceGitPage.tsx
@@ -171,9 +171,17 @@ export function WorkspaceGitPage({ workspace, subview, onSubviewChange }: Worksp
   useEffect(() => { void load(); }, [workspace.id, appliedFilters]);
 
   useEffect(() => {
+    if (
+      reference === appliedFilters.reference
+      && author === appliedFilters.author
+      && since === appliedFilters.since
+      && until === appliedFilters.until
+      && path === appliedFilters.path
+      && mergesOnly === appliedFilters.mergesOnly
+    ) return;
     const timeout = window.setTimeout(() => setAppliedFilters({ reference, author, since, until, path, mergesOnly }), 300);
     return () => window.clearTimeout(timeout);
-  }, [reference, author, since, until, path, mergesOnly]);
+  }, [reference, author, since, until, path, mergesOnly, appliedFilters]);
 
   const filteredCommits = useMemo(() => {
     const needle = search.trim().toLocaleLowerCase();


### PR DESCRIPTION
## 修改内容

- 修复 Git 页面首次挂载时，无变化的筛选 debounce 仍重复加载工作区的问题，避免已选文件被重置为完整 Commit Diff。
- 增加回归测试，验证初始 debounce 窗口后不会发生重复加载。
- 将完整 Rust/前端质量检查集中到 Ubuntu x64 核心 CI。
- 删除重复的 Ubuntu x64 平台 job；Ubuntu ARM64、Fedora x64 和 Windows 只保留平台相关 Rust 检查。
- 为平台工作流增加并发取消、超时、Rust 缓存，以及仅失败时保留 7 天的诊断日志。
- 更新 README 中的平台检查与手动打包说明。

## 根因

Git 页面初始化时会无条件安排一次 300ms 的筛选状态更新。即使筛选内容没有变化，也会创建新的状态对象并重新执行 `load()`，从而清空 `selectedFile`。较慢的 CI runner 更容易在文件选择后触发该竞态。

平台工作流同时重复运行了与操作系统无关的前端测试、typecheck 和构建，使同一个 flaky test 在一次 PR 中被执行约五次，并增加了无必要的 runner 用量。

## 验证

- `pnpm test`：123 通过，1 跳过
- `WorkspaceGitPage.test.tsx` 连续运行 5 次：全部通过
- `pnpm typecheck`
- `pnpm build`
- `cargo fmt --all -- --check`
- 使用全新临时 `CARGO_TARGET_DIR` 运行 `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- 工作流 YAML 解析
- `git diff --check`

桌面安装包仍只由手动 `Desktop Package Artifacts` 工作流生成。