### PR TITLE
ci(release): 自动发布桌面安装包

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,13 +1,21 @@
 name: Desktop Package Artifacts
 
 on:
+  push:
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing version tag to build and publish; leave empty for artifact-only builds"
+        required: false
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: desktop-packages-${{ github.ref }}
+  group: desktop-packages-${{ inputs.release_tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -16,13 +24,17 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       app_version: ${{ steps.version.outputs.app_version }}
+      release_tag: ${{ steps.release.outputs.release_tag }}
+      release_sha: ${{ steps.release.outputs.release_sha }}
+      should_publish: ${{ steps.release.outputs.should_publish }}
     env:
       CARGO_TERM_COLOR: always
     steps:
       - name: Checkout selected revision
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.release_tag || github.sha }}
+          fetch-depth: 0
 
       - name: Install Linux desktop dependencies
         run: |
@@ -86,6 +98,55 @@ jobs:
 
           echo "Validated AgentKib desktop version $tauri_version"
           echo "app_version=$tauri_version" >> "$GITHUB_OUTPUT"
+
+      - name: Validate release ref
+        id: release
+        shell: bash
+        env:
+          APP_VERSION: ${{ steps.version.outputs.app_version }}
+          PUSHED_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+          REQUESTED_TAG: ${{ inputs.release_tag || '' }}
+        run: |
+          set -euo pipefail
+
+          release_tag="$PUSHED_TAG"
+          if [[ -n "$REQUESTED_TAG" ]]; then
+            if [[ -n "$release_tag" && "$release_tag" != "$REQUESTED_TAG" ]]; then
+              echo "Selected ref tag $release_tag does not match requested tag $REQUESTED_TAG" >&2
+              exit 1
+            fi
+            release_tag="$REQUESTED_TAG"
+          fi
+
+          release_sha=$(git rev-parse 'HEAD^{commit}')
+          should_publish=false
+
+          if [[ -n "$release_tag" ]]; then
+            expected_tag="v$APP_VERSION"
+            if [[ "$release_tag" != "$expected_tag" ]]; then
+              echo "Release tag $release_tag does not match desktop version $APP_VERSION; expected $expected_tag" >&2
+              exit 1
+            fi
+
+            tag_sha=$(git rev-list -n 1 "$release_tag")
+            if [[ "$tag_sha" != "$release_sha" ]]; then
+              echo "Release tag $release_tag resolves to $tag_sha, but checkout resolved to $release_sha" >&2
+              exit 1
+            fi
+
+            git fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main'
+            if ! git merge-base --is-ancestor "$release_sha" origin/main; then
+              echo "Release commit $release_sha is not contained in origin/main" >&2
+              exit 1
+            fi
+
+            should_publish=true
+          fi
+
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
+          echo "should_publish=$should_publish" >> "$GITHUB_OUTPUT"
+          echo "Selected release revision: sha=$release_sha tag=${release_tag:-none} publish=$should_publish"
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -159,7 +220,7 @@ jobs:
       - name: Checkout selected revision
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ needs.preflight.outputs.release_sha }}
 
       - name: Install Linux desktop dependencies
         if: runner.os == 'Linux'
@@ -312,7 +373,7 @@ jobs:
       - name: Checkout selected revision
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ needs.preflight.outputs.release_sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -367,7 +428,11 @@ jobs:
           test -n "$source"
           destination="$DESKTOP_RELEASE_DIR/AgentKib_${APP_VERSION}_linux-x64.rpm"
           cp "$source" "$destination"
-          sha256sum "$destination" > "$destination.sha256"
+          (
+            cd "$DESKTOP_RELEASE_DIR"
+            artifact=$(basename "$destination")
+            sha256sum "$artifact" > "$artifact.sha256"
+          )
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
@@ -375,3 +440,194 @@ jobs:
           name: agentkib-desktop-linux-fedora-x64
           path: ${{ env.DESKTOP_RELEASE_DIR }}/*
           if-no-files-found: error
+
+  publish-release:
+    name: Publish GitHub Release
+    needs:
+      - preflight
+      - desktop
+      - fedora-x64
+    if: needs.preflight.outputs.should_publish == 'true'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    env:
+      APP_VERSION: ${{ needs.preflight.outputs.app_version }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_ASSETS_DIR: dist/github-release
+      RELEASE_SHA: ${{ needs.preflight.outputs.release_sha }}
+      RELEASE_TAG: ${{ needs.preflight.outputs.release_tag }}
+      WORKFLOW_ARTIFACTS_DIR: dist/workflow-artifacts
+
+    steps:
+      - name: Download platform artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: agentkib-desktop-*
+          path: ${{ env.WORKFLOW_ARTIFACTS_DIR }}
+
+      - name: Validate release assets and checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          prefix="AgentKib_${APP_VERSION}"
+          mkdir -p "$RELEASE_ASSETS_DIR"
+
+          while IFS= read -r -d '' source; do
+            destination="$RELEASE_ASSETS_DIR/$(basename "$source")"
+            if [[ -e "$destination" ]]; then
+              echo "Duplicate release artifact name: $(basename "$source")" >&2
+              exit 1
+            fi
+            cp "$source" "$destination"
+          done < <(find "$WORKFLOW_ARTIFACTS_DIR" -type f -print0)
+
+          cat > "$RUNNER_TEMP/expected-release-assets.txt" <<EOF
+          ${prefix}_linux-arm64-preview.AppImage
+          ${prefix}_linux-arm64-preview.AppImage.sha256
+          ${prefix}_linux-arm64-preview.deb
+          ${prefix}_linux-arm64-preview.deb.sha256
+          ${prefix}_linux-x64.AppImage
+          ${prefix}_linux-x64.AppImage.sha256
+          ${prefix}_linux-x64.deb
+          ${prefix}_linux-x64.deb.sha256
+          ${prefix}_linux-x64.rpm
+          ${prefix}_linux-x64.rpm.sha256
+          ${prefix}_macos-arm64.app.zip
+          ${prefix}_macos-arm64.app.zip.sha256
+          ${prefix}_macos-arm64.dmg
+          ${prefix}_macos-arm64.dmg.sha256
+          ${prefix}_macos-x64.app.zip
+          ${prefix}_macos-x64.app.zip.sha256
+          ${prefix}_macos-x64.dmg
+          ${prefix}_macos-x64.dmg.sha256
+          ${prefix}_windows-arm64-preview.exe
+          ${prefix}_windows-arm64-preview.exe.sha256
+          ${prefix}_windows-x64.exe
+          ${prefix}_windows-x64.exe.sha256
+          EOF
+
+          find "$RELEASE_ASSETS_DIR" -maxdepth 1 -type f -exec basename {} \; \
+            | LC_ALL=C sort > "$RUNNER_TEMP/actual-release-assets.txt"
+          LC_ALL=C sort -o "$RUNNER_TEMP/expected-release-assets.txt" \
+            "$RUNNER_TEMP/expected-release-assets.txt"
+
+          if ! diff -u "$RUNNER_TEMP/expected-release-assets.txt" \
+            "$RUNNER_TEMP/actual-release-assets.txt"; then
+            echo "Release artifact set does not match the expected manifest" >&2
+            exit 1
+          fi
+
+          while IFS= read -r artifact; do
+            test -s "$artifact"
+          done < <(find "$RELEASE_ASSETS_DIR" -maxdepth 1 -type f | LC_ALL=C sort)
+
+          while IFS= read -r checksum; do
+            (
+              cd "$RELEASE_ASSETS_DIR"
+              sha256sum -c "$(basename "$checksum")"
+            )
+          done < <(find "$RELEASE_ASSETS_DIR" -maxdepth 1 -type f -name '*.sha256' | LC_ALL=C sort)
+
+      - name: Prepare draft release
+        shell: bash
+        run: |
+          set -euo pipefail
+          query_error="$RUNNER_TEMP/release-query-error.txt"
+
+          remote_tag_sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')
+          if [[ "$remote_tag_sha" != "$RELEASE_SHA" ]]; then
+            echo "Remote tag $RELEASE_TAG resolves to $remote_tag_sha, expected $RELEASE_SHA" >&2
+            exit 1
+          fi
+
+          set +e
+          release_json=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" 2>"$query_error")
+          query_status=$?
+          set -e
+
+          if [[ "$query_status" -eq 0 ]]; then
+            if [[ "$(jq -r '.draft' <<<"$release_json")" != true ]]; then
+              echo "Release $RELEASE_TAG is already public; refusing to overwrite it" >&2
+              exit 1
+            fi
+            echo "Resuming existing draft release $RELEASE_TAG"
+          elif grep -q 'HTTP 404' "$query_error"; then
+            create_args=(
+              release create "$RELEASE_TAG"
+              --repo "$GITHUB_REPOSITORY"
+              --target "$RELEASE_SHA"
+              --title "AgentKib $RELEASE_TAG"
+              --generate-notes
+              --verify-tag
+              --draft
+            )
+            if [[ "$APP_VERSION" == *-* ]]; then
+              create_args+=(--prerelease)
+            fi
+            gh "${create_args[@]}"
+          else
+            cat "$query_error" >&2
+            exit "$query_status"
+          fi
+
+      - name: Upload release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release upload "$RELEASE_TAG" "$RELEASE_ASSETS_DIR"/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+
+      - name: Verify uploaded release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          local_manifest="$RUNNER_TEMP/local-release-assets.txt"
+          remote_manifest="$RUNNER_TEMP/remote-release-assets.txt"
+
+          for artifact in "$RELEASE_ASSETS_DIR"/*; do
+            printf '%s\t%s\n' "$(basename "$artifact")" "$(stat -c '%s' "$artifact")"
+          done | LC_ALL=C sort > "$local_manifest"
+
+          gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
+            --jq '.assets[] | [.name, .size] | @tsv' \
+            | LC_ALL=C sort > "$remote_manifest"
+
+          if ! diff -u "$local_manifest" "$remote_manifest"; then
+            echo "Uploaded release assets do not match local artifacts" >&2
+            exit 1
+          fi
+
+      - name: Publish verified release
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$APP_VERSION" == *-* ]]; then
+            gh release edit "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --draft=false \
+              --prerelease
+          else
+            gh release edit "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --draft=false \
+              --latest
+          fi
+
+          release_json=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")
+          if [[ "$(jq -r '.draft' <<<"$release_json")" != false ]]; then
+            echo "Release $RELEASE_TAG remained a draft after publication" >&2
+            exit 1
+          fi
+
+          expected_prerelease=false
+          if [[ "$APP_VERSION" == *-* ]]; then
+            expected_prerelease=true
+          fi
+          if [[ "$(jq -r '.prerelease' <<<"$release_json")" != "$expected_prerelease" ]]; then
+            echo "Release $RELEASE_TAG has an unexpected prerelease state" >&2
+            exit 1
+          fi
+
+          echo "Published $(jq -r '.html_url' <<<"$release_json")"

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 </p>
 
 > [!WARNING]
-> AgentKib 仍处于开发预览阶段，尚未提供签名并正式发布的安装包。本地数据格式和部分功能可能继续调整；目前请从源码运行。
-> AgentKib is a development preview without signed official installers. Local data formats and some features may still change; run it from source for now.
+> AgentKib 仍处于开发预览阶段，[Releases](https://github.com/starroyhq/agentkib/releases) 提供的安装包尚未签名。本地数据格式和部分功能可能继续调整；macOS Gatekeeper 和 Windows SmartScreen 可能显示安全提醒。
+> AgentKib is a development preview. Installers on [Releases](https://github.com/starroyhq/agentkib/releases) are currently unsigned, and local data formats and some features may still change. macOS Gatekeeper and Windows SmartScreen may show warnings.
 
 ## 简体中文
 
@@ -114,14 +114,14 @@ AgentKib 会区分“已安装”和“只发现了卸载后留下的本地数�
 | 平台 | 状态 |
 | --- | --- |
 | macOS 13.3+（Apple Silicon / Intel） | 主要开发与验收平台 |
-| Windows 11 x64（WebView2 111+） | PR 验证平台代码；手动工作流构建并烟测 NSIS |
-| Ubuntu 22.04 x64（WebKitGTK 2.40+） | 核心 CI 平台；手动工作流构建并验证 `.deb` 与 AppImage |
-| Fedora x64 | PR 验证平台代码；手动工作流构建并验证 `.rpm` |
-| Windows ARM64 / Linux ARM64 | Preview；验证核心编译或测试，并生成预览包 |
+| Windows 11 x64（WebView2 111+） | PR 验证平台代码；发布工作流构建并烟测 NSIS |
+| Ubuntu 22.04 x64（WebKitGTK 2.40+） | 核心 CI 平台；发布工作流构建并验证 `.deb` 与 AppImage |
+| Fedora x64 | PR 验证平台代码；发布工作流构建并验证 `.rpm` |
+| Windows ARM64 / Linux ARM64 | Preview；发布工作流生成并验证预览包 |
 
-Windows 的完整环境、启动、打包和安装说明见 [Windows 指南](docs/WINDOWS.md)。维护者可按 [桌面打包流程](docs/RELEASE.md) 手动生成未签名的多平台预览包；PR 和普通 push 只运行检查，不生成安装包。开发和验证命令见文末的[开发说明](#development)。
+Windows 的完整环境、启动、打包和安装说明见 [Windows 指南](docs/WINDOWS.md)。维护者按 [桌面发布流程](docs/RELEASE.md) 推送版本标签后，CI 会构建、校验并发布未签名的多平台预览包；PR 和普通分支 push 只运行检查，不发布安装包。开发和验证命令见文末的[开发说明](#development)。
 
-问题反馈请前往 [GitHub Issues](https://github.com/starroyhq/agentkib/issues)。未来的正式预览版本将发布在 [Releases](https://github.com/starroyhq/agentkib/releases)。
+安装包与校验文件发布在 [Releases](https://github.com/starroyhq/agentkib/releases)，问题反馈请前往 [GitHub Issues](https://github.com/starroyhq/agentkib/issues)。
 
 ---
 
@@ -252,4 +252,4 @@ pnpm typecheck
 pnpm build
 ```
 
-AgentKib is a development preview. There are no signed official downloads yet; future preview releases will be published on [Releases](https://github.com/starroyhq/agentkib/releases). For feedback, use [GitHub Issues](https://github.com/starroyhq/agentkib/issues).
+AgentKib is a development preview. Unsigned preview installers and checksums are published on [Releases](https://github.com/starroyhq/agentkib/releases); macOS Gatekeeper and Windows SmartScreen may show warnings. For feedback, use [GitHub Issues](https://github.com/starroyhq/agentkib/issues).

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,24 +1,60 @@
-# Desktop package workflow
+# Desktop release workflow
 
-AgentKib desktop packages are generated only by the manually triggered
-`Desktop Package Artifacts` GitHub Actions workflow. Pull requests and pushes
-run platform checks, but they do not create installers.
+AgentKib desktop releases are built, verified, and published by the
+`Desktop Package Artifacts` GitHub Actions workflow. Pull requests and normal
+branch pushes run platform checks but do not publish installers.
 
-## Build packages
+## Publish a release
 
-1. Open **Actions** in the GitHub repository.
-2. Select **Desktop Package Artifacts**.
-3. Choose **Run workflow** and select the branch to build. To build a tag, run
-   `gh workflow run release-desktop.yml --ref <tag>` instead.
-4. Wait for the preflight and every platform job to pass.
-5. Download the artifact for the target platform from the completed run.
+1. Update the desktop version in the workspace `Cargo.toml`,
+   `apps/desktop/package.json`, and
+   `apps/desktop/src-tauri/tauri.conf.json`.
+2. Merge the version change into `main` and make sure the required checks pass.
+3. Create an annotated version tag on that `main` commit and push only the tag:
 
-The workflow locks every job to the selected revision's commit. Before
-packaging, it verifies that the versions in the Tauri configuration, desktop
-package, and Cargo workspace match, then runs the full Rust and frontend check
-suite.
+   ```bash
+   git switch main
+   git pull --ff-only origin main
+   git tag -a v0.1.0 -m "AgentKib v0.1.0"
+   git push origin v0.1.0
+   ```
 
-## Artifacts
+4. Wait for every job in **Desktop Package Artifacts** to pass. The workflow
+   creates a draft GitHub Release only after all platform builds complete. It
+   verifies the complete asset manifest and every SHA-256 checksum, uploads the
+   files, checks their remote names and sizes, and then publishes the release.
+
+Do not create an empty GitHub Release before pushing the tag. Stable SemVer
+tags such as `v0.1.0` become the latest release. Tags containing a prerelease
+suffix, such as `v0.2.0-beta.1`, are published as prereleases.
+
+The workflow refuses to publish when the tag does not exactly match the
+desktop version, the three version sources differ, or the tagged commit is not
+contained in `origin/main`. Every build job checks out the same resolved commit.
+
+## Retry a failed release
+
+If a run fails because of a transient runner, network, repository setting, or
+workflow problem after creating the draft, fix the underlying problem without
+publishing the incomplete draft, then run the workflow against the existing
+tag:
+
+```bash
+gh workflow run release-desktop.yml --ref main -f release_tag=v0.1.0
+```
+
+The retry rebuilds every platform, resumes an existing draft, and replaces
+same-named draft assets. It refuses to overwrite a release that is already
+public. A product-code fix requires a new version and tag rather than moving an
+existing tag. Workflow artifacts remain available for diagnosing failed builds.
+
+## Build artifacts without publishing
+
+To create packages for a branch without creating a GitHub Release, open
+**Actions**, select **Desktop Package Artifacts**, choose **Run workflow**, pick
+the branch, and leave `release_tag` empty.
+
+The run produces these downloadable workflow artifacts:
 
 - `agentkib-desktop-macos-arm64`: zipped `.app`, DMG, and checksums.
 - `agentkib-desktop-macos-x64`: zipped `.app`, DMG, and checksums.
@@ -29,7 +65,7 @@ suite.
 - `agentkib-desktop-linux-fedora-x64`: RPM and checksum.
 
 Each checksum file is named after its package with the `.sha256` suffix. Verify
-the downloaded package before installing it, for example:
+a downloaded package before installing it, for example:
 
 ```bash
 shasum -a 256 -c AgentKib_0.1.0_macos-arm64.dmg.sha256
@@ -40,11 +76,10 @@ file with `Get-FileHash <installer> -Algorithm SHA256`.
 
 ## Preview limitations
 
-These workflow artifacts are unsigned development previews. They are not
-attached to a GitHub Release and do not include macOS notarization, Windows
-code signing, MSI packages, a macOS universal binary, or automatic updates.
-macOS Gatekeeper and Windows SmartScreen may therefore display warnings.
+Release packages are unsigned development previews. They do not include macOS
+notarization, Windows code signing, MSI packages, a macOS universal binary, or
+automatic updates. macOS Gatekeeper and Windows SmartScreen may therefore
+display warnings.
 
-Before sharing a build, confirm that all platform jobs passed and test the
-downloaded package on the intended operating system. ARM64 packages remain
-preview-only until they have been verified on representative hardware.
+ARM64 Windows and Linux packages remain preview-only until they have been
+verified on representative hardware.

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -196,11 +196,12 @@ Get-NetTCPConnection -LocalPort 1420 -ErrorAction SilentlyContinue
 
 ### SmartScreen 阻止安装
 
-第一阶段安装包未签名，可能触发 SmartScreen。只对自己刚构建且路径、时间和文件名均确认无误的安装包选择“更多信息”并继续；正式分发前应增加代码签名。
+当前安装包未签名，可能触发 SmartScreen。只对从 AgentKib GitHub Releases 下载且 SHA-256 校验一致，或自己刚构建并确认路径、时间和文件名无误的安装包选择“更多信息”并继续；后续正式签名版本应移除这项限制。
 
 ## 当前阶段限制
 
 - 已验收目标仅为 Windows 11 x64 的编译、开发启动、NSIS 安装和启动。
-- Windows ARM64、代码签名、自动更新和正式发布不在本阶段范围内。
+- Windows ARM64 仅提供 Preview 安装包，尚未完成与 x64 等价的原生回归。
+- GitHub Release 已由版本标签自动发布；Windows 代码签名和自动更新仍不在本阶段范围内。
 - macOS/Linux 行为通过平台隔离和现有 CI 保持，本机无法替代对应平台的原生回归。
 - 完整 Windows 功能等价测试仍需后续阶段逐项完成。


### PR DESCRIPTION
## 修改内容

- 推送版本标签后自动完成预检、七个平台构建与 GitHub Release 发布
- 支持通过 release_tag 重试已有标签的发布流程
- 发布前完整校验安装包、校验文件、文件名、大小与哈希
- 更新 README 和发布文档，说明自动发布及未签名预览包限制

## 验证

- actionlint：通过
- Workflow YAML 与 Bash 语法检查：通过
- 发布标签、产物清单和草稿状态模拟：通过
- pnpm test：154 通过，1 跳过
- pnpm typecheck：通过
- pnpm build：通过
- cargo test --workspace：通过
- cargo fmt --all -- --check：通过
- cargo clippy --workspace --all-targets -- -D warnings：通过
- git diff --check：通过

## 备注

- 本 PR 不创建版本标签或 Release
- 不包含未跟踪的 .idea/ 文件