### PR TITLE
ci(release): 添加 macOS 未签名安装提示

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -560,12 +560,21 @@ jobs:
             fi
             echo "Resuming existing draft release $RELEASE_TAG"
           else
+            release_notes=$(
+              cat <<'EOF'
+          > [!WARNING]
+          > macOS 安装包目前尚未签名和公证。核对 `.sha256` 校验文件并将 AgentKib 拖入“应用程序”后，请执行 `xattr -cr /Applications/AgentKib.app`。只应对从本 Release 下载且校验通过的应用执行此命令。
+          >
+          > The macOS package is not signed or notarized. After verifying its `.sha256` file and dragging AgentKib into Applications, run `xattr -cr /Applications/AgentKib.app`. Only use this command for the verified app downloaded from this Release.
+          EOF
+            )
             create_args=(
               release create "$RELEASE_TAG"
               --repo "$GITHUB_REPOSITORY"
               --target "$RELEASE_SHA"
               --title "AgentKib $RELEASE_TAG"
               --generate-notes
+              --notes "$release_notes"
               --verify-tag
               --draft
             )

--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ Windows 的完整环境、启动、打包和安装说明见 [Windows 指南](doc
 
 安装包与校验文件发布在 [Releases](https://github.com/starroyhq/agentkib/releases)，问题反馈请前往 [GitHub Issues](https://github.com/starroyhq/agentkib/issues)。
 
+macOS 安装包目前尚未签名和公证。请先核对 Release 中的 SHA-256 校验文件，将 AgentKib 拖入“应用程序”后，再执行以下命令解除隔离属性：
+
+```bash
+xattr -cr /Applications/AgentKib.app
+```
+
+只应对从 AgentKib 官方 Releases 下载且校验通过的应用执行此命令。
+
 ---
 
 ## English
@@ -223,6 +231,14 @@ Optional Obsidian and OpenClaw/Hermes Remote Gateway integrations must be config
 | Windows ARM64 / Linux ARM64 | Preview; core compilation or tests plus preview packages |
 
 See the [Windows guide](docs/WINDOWS.md) for setup, development, packaging, installation, and usage. Maintainers can generate unsigned multi-platform preview packages with the [desktop package workflow](docs/RELEASE.md). Pull requests and ordinary pushes run checks without producing installers.
+
+The macOS package is not currently signed or notarized. Verify it against the SHA-256 file in the Release, drag AgentKib into Applications, and then remove its quarantine attributes:
+
+```bash
+xattr -cr /Applications/AgentKib.app
+```
+
+Only run this command for an app downloaded from the official AgentKib Releases page whose checksum you have verified.
 
 <a id="development"></a>
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -81,5 +81,17 @@ notarization, Windows code signing, MSI packages, a macOS universal binary, or
 automatic updates. macOS Gatekeeper and Windows SmartScreen may therefore
 display warnings.
 
+After verifying the downloaded DMG against its `.sha256` file and copying
+AgentKib into Applications, macOS users must currently remove the quarantine
+attributes before opening the app:
+
+```bash
+xattr -cr /Applications/AgentKib.app
+```
+
+This command bypasses Gatekeeper's quarantine check. It must only be used for
+an AgentKib package downloaded from the official GitHub Release whose checksum
+has been verified.
+
 ARM64 Windows and Linux packages remain preview-only until they have been
 verified on representative hardware.


### PR DESCRIPTION
## Summary

- 在中英文 README 中说明未签名 macOS 包的校验与解除隔离步骤
- 在发布维护文档中补充 `xattr -cr /Applications/AgentKib.app` 及安全边界
- 在自动生成的 GitHub Release Notes 顶部加入同样的中英文提示

当前公开的 v0.1.0 Release Notes 已同步补充该提示。

## Validation

- `git diff --check`
- Workflow YAML 解析
- `Prepare draft release` Shell 语法检查