### PR TITLE
chore(release): 准备 v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentkib-adapters"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-core",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-conversations"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-desktop"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-conversations",
@@ -109,7 +109,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-discovery"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-gateways"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-git"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-insights"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-mcp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-platform"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hex",
  "libc",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-quota"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-storage"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agentkib-platform",
  "chrono",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-store"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "agentkib-conversations",
  "agentkib-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentkib/desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AgentKib",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "ai.agentkib",
   "build": {
     "beforeDevCommand": "pnpm quota:prepare && pnpm dev:web",


### PR DESCRIPTION
## Summary

- 将 Cargo workspace 版本更新为 0.2.0
- 同步桌面 package 与 Tauri 应用版本
- 更新 Cargo.lock 中所有 AgentKib workspace crate 版本

## Validation

- `cargo check --workspace`
- 三处发布版本一致性校验
- `git diff --check`