### PR TITLE
chore(release): 准备 v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentkib-adapters"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-core",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-conversations"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-desktop"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-conversations",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-discovery"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-gateways"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-git"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-insights"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-mcp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-platform"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "hex",
  "libc",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-quota"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-storage"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agentkib-platform",
  "chrono",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-store"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "agentkib-conversations",
  "agentkib-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "MIT"
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentkib/desktop",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AgentKib",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "ai.agentkib",
   "build": {
     "beforeDevCommand": "pnpm quota:prepare && pnpm dev:web",


### PR DESCRIPTION
## Summary

- 将 Cargo workspace、桌面 package 和 Tauri 应用版本同步升级到 `0.3.0`
- 更新 workspace crate 的锁文件版本
- 作为首个支持 Tauri Updater 的手动引导版本

## Validation

- `cargo check -p agentkib-desktop`
- `pnpm typecheck`
- updater manifest 单元测试
- Rust/前端格式检查
- 三处发布版本一致性校验
- PR #17 的 Windows、Linux 与主 CI 已全部通过