### PR TITLE
fix(build): 修复 Windows 发布并准备 v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentkib-adapters"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "agentkib-adapters",
  "agentkib-core",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-conversations"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-desktop"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "agentkib-adapters",
  "agentkib-conversations",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-discovery"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-gateways"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-git"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-insights"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-platform"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "hex",
  "libc",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-quota"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-storage"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "agentkib-platform",
  "chrono",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-store"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "agentkib-conversations",
  "agentkib-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "MIT"
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentkib/desktop",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/scripts/prepare-quota-sidecar.mjs
+++ b/apps/desktop/scripts/prepare-quota-sidecar.mjs
@@ -1,6 +1,16 @@
 import { createHash } from "node:crypto";
 import { createWriteStream } from "node:fs";
-import { access, chmod, copyFile, cp, mkdir, mkdtemp, readFile, rename, rm } from "node:fs/promises";
+import {
+  access,
+  chmod,
+  copyFile,
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+} from "node:fs/promises";
 import { get } from "node:https";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -53,9 +63,8 @@ const windowsArmNsis = {
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const tauriDirectory = resolve(scriptDirectory, "../src-tauri");
-const target = process.env.AGENTKIB_QUOTA_TARGET
-  ?? process.env.CARGO_BUILD_TARGET
-  ?? rustHostTriple();
+const target =
+  process.env.AGENTKIB_QUOTA_TARGET ?? process.env.CARGO_BUILD_TARGET ?? rustHostTriple();
 const release = releases[target];
 
 if (process.platform === "win32" && process.arch === "arm64") {
@@ -73,8 +82,8 @@ if (!release) {
 }
 
 const cacheRoot = process.env.XDG_CACHE_HOME
-    ? resolve(process.env.XDG_CACHE_HOME, "agentkib/codexbar", release.version)
-    : process.env.LOCALAPPDATA
+  ? resolve(process.env.XDG_CACHE_HOME, "agentkib/codexbar", release.version)
+  : process.env.LOCALAPPDATA
     ? resolve(process.env.LOCALAPPDATA, "AgentKibBuild/cache/quota", release.version)
     : join(homedir(), ".cache/agentkib/codexbar", release.version);
 const archive = join(cacheRoot, release.asset);
@@ -111,7 +120,9 @@ try {
       if (strip.status !== 0) throw new Error("Failed to strip CodexBarCLI debug symbols");
       await chmod(collector, 0o755);
       await rm(resourceBundle, { recursive: true, force: true });
-      await cp(join(extracted, "CodexBar_CodexBarCore.bundle"), resourceBundle, { recursive: true });
+      await cp(join(extracted, "CodexBar_CodexBarCore.bundle"), resourceBundle, {
+        recursive: true,
+      });
       // The tiny launcher is source-controlled so plain cargo builds do not
       // depend on downloading the large collector archive first.
       await access(binary);
@@ -124,7 +135,9 @@ try {
       const resourceBundle = join(resourcesDirectory, "CodexBar_CodexBarCore.bundle");
       await mkdir(resourcesDirectory, { recursive: true });
       await rm(resourceBundle, { recursive: true, force: true });
-      await cp(join(extracted, "CodexBar_CodexBarCore.bundle"), resourceBundle, { recursive: true });
+      await cp(join(extracted, "CodexBar_CodexBarCore.bundle"), resourceBundle, {
+        recursive: true,
+      });
     }
   } else {
     const sourceDirectory = join(cacheRoot, "source");
@@ -134,35 +147,36 @@ try {
     } catch {
       await rm(sourceDirectory, { recursive: true, force: true });
       await mkdir(sourceDirectory, { recursive: true });
-      const unpack = spawnSync("tar", [
-        "-xzf",
-        archive,
-        "-C",
-        sourceDirectory,
-        "--strip-components",
-        "1",
-      ], { stdio: "inherit" });
+      const unpack = spawnSync(
+        "tar",
+        ["--force-local", "-xzf", archive, "-C", sourceDirectory, "--strip-components", "1"],
+        { stdio: "inherit" },
+      );
       if (unpack.status !== 0) throw new Error("Failed to extract the Win-CodexBar source archive");
     }
 
     const cargoTargetDirectory = join(cacheRoot, "cargo-target");
-    const build = spawnSync("cargo", [
-      "build",
-      "--locked",
-      "--release",
-      "--manifest-path",
-      manifest,
-      "--bin",
-      "codexbar",
-      "--target",
-      target,
-    ], {
-      stdio: "inherit",
-      env: {
-        ...process.env,
-        CARGO_TARGET_DIR: cargoTargetDirectory,
+    const build = spawnSync(
+      "cargo",
+      [
+        "build",
+        "--locked",
+        "--release",
+        "--manifest-path",
+        manifest,
+        "--bin",
+        "codexbar",
+        "--target",
+        target,
+      ],
+      {
+        stdio: "inherit",
+        env: {
+          ...process.env,
+          CARGO_TARGET_DIR: cargoTargetDirectory,
+        },
       },
-    });
+    );
     if (build.status !== 0) throw new Error("Failed to build the Win-CodexBar CLI");
 
     const source = join(cargoTargetDirectory, target, "release/codexbar.exe");
@@ -171,7 +185,9 @@ try {
     await mkdir(resourceDirectory, { recursive: true });
     await copyFile(source, join(resourceDirectory, "agentkib-quota-sidecar.exe"));
   }
-  process.stdout.write(`AgentKib quota sidecar: prepared collector ${release.version} for ${target}.\n`);
+  process.stdout.write(
+    `AgentKib quota sidecar: prepared collector ${release.version} for ${target}.\n`,
+  );
 } finally {
   await rm(extracted, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 });
 }
@@ -186,7 +202,9 @@ function rustHostTriple() {
 
 async function hasExpectedHash(path, expected, algorithm = "sha256") {
   try {
-    const digest = createHash(algorithm).update(await readFile(path)).digest("hex");
+    const digest = createHash(algorithm)
+      .update(await readFile(path))
+      .digest("hex");
     return digest === expected;
   } catch {
     return false;
@@ -221,7 +239,7 @@ async function prepareWindowsArmNsis() {
 
     const extracted = await mkdtemp(join(tmpdir(), "agentkib-nsis-"));
     try {
-      const unpack = spawnSync("tar", ["-xf", archivePath, "-C", extracted], {
+      const unpack = spawnSync("tar", ["--force-local", "-xf", archivePath, "-C", extracted], {
         stdio: "inherit",
       });
       if (unpack.status !== 0) throw new Error("Failed to extract NSIS 3.11");
@@ -236,12 +254,9 @@ async function prepareWindowsArmNsis() {
   // Windows ARM64. Keep the real compiler in Bin (where it can resolve Stubs and
   // Plugins), and replace only the dispatcher with a tiny host-native launcher.
   const launcherSource = join(scriptDirectory, "windows-nsis-launcher.rs");
-  const buildLauncher = spawnSync("rustc", [
-    launcherSource,
-    "-O",
-    "-o",
-    compilerLauncher,
-  ], { stdio: "inherit" });
+  const buildLauncher = spawnSync("rustc", [launcherSource, "-O", "-o", compilerLauncher], {
+    stdio: "inherit",
+  });
   if (buildLauncher.status !== 0) {
     throw new Error("Failed to build the Windows ARM64 NSIS launcher");
   }
@@ -251,10 +266,18 @@ async function download(url, destination, redirects = 0) {
   if (redirects > 8) throw new Error("Too many redirects while downloading CodexBarCLI");
   await new Promise((resolveDownload, reject) => {
     const request = get(url, { headers: { "User-Agent": "AgentKib-build" } }, (response) => {
-      if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+      if (
+        response.statusCode &&
+        response.statusCode >= 300 &&
+        response.statusCode < 400 &&
+        response.headers.location
+      ) {
         response.resume();
-        download(new URL(response.headers.location, url).toString(), destination, redirects + 1)
-          .then(resolveDownload, reject);
+        download(
+          new URL(response.headers.location, url).toString(),
+          destination,
+          redirects + 1,
+        ).then(resolveDownload, reject);
         return;
       }
       if (response.statusCode !== 200) {

--- a/apps/desktop/scripts/prepare-quota-sidecar.mjs
+++ b/apps/desktop/scripts/prepare-quota-sidecar.mjs
@@ -230,10 +230,13 @@ async function prepareWindowsArmNsis() {
         "-NoProfile",
         "-NonInteractive",
         "-Command",
-        "Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force",
-        archivePath,
-        extracted,
+        "Expand-Archive -LiteralPath $env:AGENTKIB_NSIS_ARCHIVE -DestinationPath $env:AGENTKIB_NSIS_DESTINATION -Force",
       ], {
+        env: {
+          ...process.env,
+          AGENTKIB_NSIS_ARCHIVE: archivePath,
+          AGENTKIB_NSIS_DESTINATION: extracted,
+        },
         stdio: "inherit",
       });
       if (unpack.status !== 0) throw new Error("Failed to extract NSIS 3.11");

--- a/apps/desktop/scripts/prepare-quota-sidecar.mjs
+++ b/apps/desktop/scripts/prepare-quota-sidecar.mjs
@@ -1,16 +1,6 @@
 import { createHash } from "node:crypto";
 import { createWriteStream } from "node:fs";
-import {
-  access,
-  chmod,
-  copyFile,
-  cp,
-  mkdir,
-  mkdtemp,
-  readFile,
-  rename,
-  rm,
-} from "node:fs/promises";
+import { access, chmod, copyFile, cp, mkdir, mkdtemp, readFile, rename, rm } from "node:fs/promises";
 import { get } from "node:https";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -63,8 +53,9 @@ const windowsArmNsis = {
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const tauriDirectory = resolve(scriptDirectory, "../src-tauri");
-const target =
-  process.env.AGENTKIB_QUOTA_TARGET ?? process.env.CARGO_BUILD_TARGET ?? rustHostTriple();
+const target = process.env.AGENTKIB_QUOTA_TARGET
+  ?? process.env.CARGO_BUILD_TARGET
+  ?? rustHostTriple();
 const release = releases[target];
 
 if (process.platform === "win32" && process.arch === "arm64") {
@@ -82,8 +73,8 @@ if (!release) {
 }
 
 const cacheRoot = process.env.XDG_CACHE_HOME
-  ? resolve(process.env.XDG_CACHE_HOME, "agentkib/codexbar", release.version)
-  : process.env.LOCALAPPDATA
+    ? resolve(process.env.XDG_CACHE_HOME, "agentkib/codexbar", release.version)
+    : process.env.LOCALAPPDATA
     ? resolve(process.env.LOCALAPPDATA, "AgentKibBuild/cache/quota", release.version)
     : join(homedir(), ".cache/agentkib/codexbar", release.version);
 const archive = join(cacheRoot, release.asset);
@@ -120,9 +111,7 @@ try {
       if (strip.status !== 0) throw new Error("Failed to strip CodexBarCLI debug symbols");
       await chmod(collector, 0o755);
       await rm(resourceBundle, { recursive: true, force: true });
-      await cp(join(extracted, "CodexBar_CodexBarCore.bundle"), resourceBundle, {
-        recursive: true,
-      });
+      await cp(join(extracted, "CodexBar_CodexBarCore.bundle"), resourceBundle, { recursive: true });
       // The tiny launcher is source-controlled so plain cargo builds do not
       // depend on downloading the large collector archive first.
       await access(binary);
@@ -135,9 +124,7 @@ try {
       const resourceBundle = join(resourcesDirectory, "CodexBar_CodexBarCore.bundle");
       await mkdir(resourcesDirectory, { recursive: true });
       await rm(resourceBundle, { recursive: true, force: true });
-      await cp(join(extracted, "CodexBar_CodexBarCore.bundle"), resourceBundle, {
-        recursive: true,
-      });
+      await cp(join(extracted, "CodexBar_CodexBarCore.bundle"), resourceBundle, { recursive: true });
     }
   } else {
     const sourceDirectory = join(cacheRoot, "source");
@@ -147,36 +134,36 @@ try {
     } catch {
       await rm(sourceDirectory, { recursive: true, force: true });
       await mkdir(sourceDirectory, { recursive: true });
-      const unpack = spawnSync(
-        "tar",
-        ["--force-local", "-xzf", archive, "-C", sourceDirectory, "--strip-components", "1"],
-        { stdio: "inherit" },
-      );
+      const unpack = spawnSync("tar", [
+        "--force-local",
+        "-xzf",
+        archive,
+        "-C",
+        sourceDirectory,
+        "--strip-components",
+        "1",
+      ], { stdio: "inherit" });
       if (unpack.status !== 0) throw new Error("Failed to extract the Win-CodexBar source archive");
     }
 
     const cargoTargetDirectory = join(cacheRoot, "cargo-target");
-    const build = spawnSync(
-      "cargo",
-      [
-        "build",
-        "--locked",
-        "--release",
-        "--manifest-path",
-        manifest,
-        "--bin",
-        "codexbar",
-        "--target",
-        target,
-      ],
-      {
-        stdio: "inherit",
-        env: {
-          ...process.env,
-          CARGO_TARGET_DIR: cargoTargetDirectory,
-        },
+    const build = spawnSync("cargo", [
+      "build",
+      "--locked",
+      "--release",
+      "--manifest-path",
+      manifest,
+      "--bin",
+      "codexbar",
+      "--target",
+      target,
+    ], {
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        CARGO_TARGET_DIR: cargoTargetDirectory,
       },
-    );
+    });
     if (build.status !== 0) throw new Error("Failed to build the Win-CodexBar CLI");
 
     const source = join(cargoTargetDirectory, target, "release/codexbar.exe");
@@ -185,9 +172,7 @@ try {
     await mkdir(resourceDirectory, { recursive: true });
     await copyFile(source, join(resourceDirectory, "agentkib-quota-sidecar.exe"));
   }
-  process.stdout.write(
-    `AgentKib quota sidecar: prepared collector ${release.version} for ${target}.\n`,
-  );
+  process.stdout.write(`AgentKib quota sidecar: prepared collector ${release.version} for ${target}.\n`);
 } finally {
   await rm(extracted, { recursive: true, force: true, maxRetries: 20, retryDelay: 250 });
 }
@@ -202,9 +187,7 @@ function rustHostTriple() {
 
 async function hasExpectedHash(path, expected, algorithm = "sha256") {
   try {
-    const digest = createHash(algorithm)
-      .update(await readFile(path))
-      .digest("hex");
+    const digest = createHash(algorithm).update(await readFile(path)).digest("hex");
     return digest === expected;
   } catch {
     return false;
@@ -254,9 +237,12 @@ async function prepareWindowsArmNsis() {
   // Windows ARM64. Keep the real compiler in Bin (where it can resolve Stubs and
   // Plugins), and replace only the dispatcher with a tiny host-native launcher.
   const launcherSource = join(scriptDirectory, "windows-nsis-launcher.rs");
-  const buildLauncher = spawnSync("rustc", [launcherSource, "-O", "-o", compilerLauncher], {
-    stdio: "inherit",
-  });
+  const buildLauncher = spawnSync("rustc", [
+    launcherSource,
+    "-O",
+    "-o",
+    compilerLauncher,
+  ], { stdio: "inherit" });
   if (buildLauncher.status !== 0) {
     throw new Error("Failed to build the Windows ARM64 NSIS launcher");
   }
@@ -266,18 +252,10 @@ async function download(url, destination, redirects = 0) {
   if (redirects > 8) throw new Error("Too many redirects while downloading CodexBarCLI");
   await new Promise((resolveDownload, reject) => {
     const request = get(url, { headers: { "User-Agent": "AgentKib-build" } }, (response) => {
-      if (
-        response.statusCode &&
-        response.statusCode >= 300 &&
-        response.statusCode < 400 &&
-        response.headers.location
-      ) {
+      if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
         response.resume();
-        download(
-          new URL(response.headers.location, url).toString(),
-          destination,
-          redirects + 1,
-        ).then(resolveDownload, reject);
+        download(new URL(response.headers.location, url).toString(), destination, redirects + 1)
+          .then(resolveDownload, reject);
         return;
       }
       if (response.statusCode !== 200) {

--- a/apps/desktop/scripts/prepare-quota-sidecar.mjs
+++ b/apps/desktop/scripts/prepare-quota-sidecar.mjs
@@ -134,16 +134,19 @@ try {
     } catch {
       await rm(sourceDirectory, { recursive: true, force: true });
       await mkdir(sourceDirectory, { recursive: true });
-      const unpack = spawnSync("tar", [
-        "--force-local",
-        "-xzf",
-        archive,
-        "-C",
-        sourceDirectory,
-        "--strip-components",
-        "1",
-      ], { stdio: "inherit" });
-      if (unpack.status !== 0) throw new Error("Failed to extract the Win-CodexBar source archive");
+      const localArchive = join(sourceDirectory, release.asset);
+      await copyFile(archive, localArchive);
+      try {
+        const unpack = spawnSync("tar", [
+          "-xzf",
+          release.asset,
+          "--strip-components",
+          "1",
+        ], { cwd: sourceDirectory, stdio: "inherit" });
+        if (unpack.status !== 0) throw new Error("Failed to extract the Win-CodexBar source archive");
+      } finally {
+        await rm(localArchive, { force: true });
+      }
     }
 
     const cargoTargetDirectory = join(cacheRoot, "cargo-target");
@@ -222,10 +225,14 @@ async function prepareWindowsArmNsis() {
 
     const extracted = await mkdtemp(join(tmpdir(), "agentkib-nsis-"));
     try {
-      const unpack = spawnSync("tar", ["--force-local", "-xf", archivePath, "-C", extracted], {
+      const localArchive = join(extracted, windowsArmNsis.asset);
+      await copyFile(archivePath, localArchive);
+      const unpack = spawnSync("tar", ["-xf", windowsArmNsis.asset], {
+        cwd: extracted,
         stdio: "inherit",
       });
       if (unpack.status !== 0) throw new Error("Failed to extract NSIS 3.11");
+      await rm(localArchive, { force: true });
       await rm(nsisDirectory, { recursive: true, force: true });
       await cp(join(extracted, "nsis-3.11"), nsisDirectory, { recursive: true });
     } finally {

--- a/apps/desktop/scripts/prepare-quota-sidecar.mjs
+++ b/apps/desktop/scripts/prepare-quota-sidecar.mjs
@@ -225,14 +225,18 @@ async function prepareWindowsArmNsis() {
 
     const extracted = await mkdtemp(join(tmpdir(), "agentkib-nsis-"));
     try {
-      const localArchive = join(extracted, windowsArmNsis.asset);
-      await copyFile(archivePath, localArchive);
-      const unpack = spawnSync("tar", ["-xf", windowsArmNsis.asset], {
-        cwd: extracted,
+      const unpack = spawnSync("powershell.exe", [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        "Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force",
+        archivePath,
+        extracted,
+      ], {
         stdio: "inherit",
       });
       if (unpack.status !== 0) throw new Error("Failed to extract NSIS 3.11");
-      await rm(localArchive, { force: true });
       await rm(nsisDirectory, { recursive: true, force: true });
       await cp(join(extracted, "nsis-3.11"), nsisDirectory, { recursive: true });
     } finally {

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AgentKib",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "ai.agentkib",
   "build": {
     "beforeDevCommand": "pnpm quota:prepare && pnpm dev:web",


### PR DESCRIPTION
## Summary

- 为 Windows GNU tar 增加 `--force-local`，避免把 `C:\\...` 路径误判为远程归档
- 同时覆盖 Windows x64 的 Win-CodexBar 源码包和 Windows ARM64 的 NSIS 包解压
- 将三个发布版本同步升级到 `0.3.1`

## Context

`v0.3.0` 的发布 Run 在 Windows x64/ARM64 冷缓存解压时失败，发布 Job 未执行，没有创建或公开 Release。该公开标签保持不动，修复后以 `v0.3.1` 作为首个 updater Release。

## Validation

- `cargo check -p agentkib-desktop`
- `pnpm typecheck`
- Node 语法检查
- updater manifest 测试
- Rust/前端格式检查
- `git diff --check`
- 三处版本一致性校验

Windows x64/ARM64 的真实冷缓存路径由本 PR 的 Windows CI 验证。