### PR TITLE
ci(release): 为 macOS 发布启用签名和公证

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -148,16 +148,38 @@ jobs:
           echo "should_publish=$should_publish" >> "$GITHUB_OUTPUT"
           echo "Selected release revision: sha=$release_sha tag=${release_tag:-none} publish=$should_publish"
 
-      - name: Validate updater signing secrets
+      - name: Validate release signing secrets
         if: steps.release.outputs.should_publish == 'true'
         shell: bash
         env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          HAS_APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER != '' }}
+          HAS_APPLE_API_KEY: ${{ secrets.APPLE_API_KEY != '' }}
+          HAS_APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY != '' }}
+          HAS_APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE != '' }}
+          HAS_APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD != '' }}
+          HAS_APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY != '' }}
+          HAS_APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID != '' }}
+          HAS_TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' }}
+          HAS_TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD != '' }}
         run: |
           set -euo pipefail
-          test -n "$TAURI_SIGNING_PRIVATE_KEY"
-          test -n "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD"
+          required=(
+            HAS_APPLE_API_ISSUER
+            HAS_APPLE_API_KEY
+            HAS_APPLE_API_PRIVATE_KEY
+            HAS_APPLE_CERTIFICATE
+            HAS_APPLE_CERTIFICATE_PASSWORD
+            HAS_APPLE_SIGNING_IDENTITY
+            HAS_APPLE_TEAM_ID
+            HAS_TAURI_SIGNING_PRIVATE_KEY
+            HAS_TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+          )
+          for name in "${required[@]}"; do
+            if [[ "${!name}" != true ]]; then
+              echo "Required release secret is missing: ${name#HAS_}" >&2
+              exit 1
+            fi
+          done
 
       - name: Test updater manifest generator
         run: node --test .github/scripts/build-updater-manifest.test.mjs
@@ -279,6 +301,20 @@ jobs:
         shell: bash
         run: find target -type d -path '*/release/bundle' -prune -exec rm -rf '{}' + 2>/dev/null || true
 
+      - name: Prepare Apple notarization private key
+        if: runner.os == 'macOS' && env.SHOULD_PUBLISH == 'true'
+        shell: bash
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY}.p8"
+          umask 077
+          printf '%s' "$APPLE_API_PRIVATE_KEY" > "$key_path"
+          test -s "$key_path"
+          echo "APPLE_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+
       - name: Build Linux bundles
         if: runner.os == 'Linux'
         shell: bash
@@ -289,8 +325,28 @@ jobs:
           fi
           apps/desktop/scripts/build-linux-bundles.sh "${args[@]}"
 
-      - name: Build macOS or Windows bundles
-        if: runner.os != 'Linux'
+      - name: Build unsigned macOS preview bundles
+        if: runner.os == 'macOS' && env.SHOULD_PUBLISH != 'true'
+        shell: bash
+        run: pnpm tauri build --bundles '${{ matrix.bundles }}'
+
+      - name: Build signed and notarized macOS release bundles
+        if: runner.os == 'macOS' && env.SHOULD_PUBLISH == 'true'
+        shell: bash
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          pnpm tauri build \
+            --bundles '${{ matrix.bundles }}' \
+            --config src-tauri/tauri.release.conf.json
+
+      - name: Build Windows bundles
+        if: runner.os == 'Windows'
         shell: bash
         run: |
           args=(--bundles '${{ matrix.bundles }}')
@@ -328,6 +384,31 @@ jobs:
           executable=$(find "$app/Contents/MacOS" -maxdepth 1 -type f -perm -u+x -print -quit)
           test -n "$executable"
           echo "Verified macOS application executable: $executable"
+
+      - name: Verify signed and notarized macOS release
+        if: runner.os == 'macOS' && env.SHOULD_PUBLISH == 'true'
+        shell: bash
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          app=$(find target -type d -path '*/bundle/macos/*.app' -print -quit)
+          test -n "$app"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          signing_details=$(codesign --display --verbose=4 "$app" 2>&1)
+          grep -F "Authority=$APPLE_SIGNING_IDENTITY" <<< "$signing_details"
+          grep -F "TeamIdentifier=${APPLE_TEAM_ID}" <<< "$signing_details"
+          xcrun stapler validate "$app"
+          spctl --assess --type execute --verbose=2 "$app"
+
+      - name: Remove Apple notarization private key
+        if: runner.os == 'macOS' && always()
+        shell: bash
+        run: |
+          if [[ -n "${APPLE_API_KEY_PATH:-}" ]]; then
+            rm -f "$APPLE_API_KEY_PATH"
+          fi
 
       - name: Stage release artifacts
         shell: bash
@@ -642,10 +723,10 @@ jobs:
           else
             release_notes=$(
               cat <<'EOF'
-          > [!WARNING]
-          > macOS 安装包目前尚未签名和公证。核对 `.sha256` 校验文件并将 AgentKib 拖入“应用程序”后，请执行 `xattr -cr /Applications/AgentKib.app`。只应对从本 Release 下载且校验通过的应用执行此命令。
+          > [!NOTE]
+          > macOS 安装包已使用 AgentKib 的 Developer ID Application 证书签名并通过 Apple 公证，可直接拖入“应用程序”后打开。
           >
-          > The macOS package is not signed or notarized. After verifying its `.sha256` file and dragging AgentKib into Applications, run `xattr -cr /Applications/AgentKib.app`. Only use this command for the verified app downloaded from this Release.
+          > The macOS packages are signed with AgentKib's Developer ID Application certificate and notarized by Apple. Drag AgentKib into Applications and open it normally.
           EOF
             )
             create_args=(

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentkib-adapters"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "agentkib-adapters",
  "agentkib-core",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-conversations"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-desktop"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "agentkib-adapters",
  "agentkib-conversations",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-discovery"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-gateways"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-git"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-insights"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-mcp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-platform"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "hex",
  "libc",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-quota"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-storage"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "agentkib-platform",
  "chrono",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-store"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "agentkib-conversations",
  "agentkib-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Download the package for your platform from the [Latest Release](https://github.
 - Windows 11: x64 `.exe`; the ARM64 installer remains a preview
 - Linux: Ubuntu `.deb` or AppImage, or Fedora `.rpm`; ARM64 packages remain previews
 
-The packages are not yet notarized on macOS or code-signed on Windows. Only use files from the official Release and verify the matching `.sha256` file. See [Platform status](#platform-status) below for the additional macOS installation step.
+macOS packages newer than v0.3.1 are signed with AgentKib's Developer ID Application certificate and notarized by Apple. v0.3.1 and earlier remain unsigned historical packages. Windows packages are not yet Authenticode-signed. Only use files from the official Release and verify the matching `.sha256` file.
 
 **v0.3.1 is the first release with in-app update support.** Versions older than v0.3.1 must first be upgraded manually. After that, check for updates under Settings → General. macOS, Windows, and Linux AppImage support in-app installation; DEB/RPM installations open the Release page for a package-manager-safe update.
 
@@ -254,9 +254,9 @@ Optional Obsidian and OpenClaw/Hermes Remote Gateway integrations must be config
 | Fedora x64 | Platform code checked on PRs; release workflow builds and verifies `.rpm` |
 | Windows ARM64 / Linux ARM64 | Preview; release workflow builds and verifies preview packages |
 
-See the [Windows guide](docs/WINDOWS.md) for setup, development, packaging, installation, and usage. Maintainers publish unsigned multi-platform preview packages through the [desktop release workflow](docs/RELEASE.md). Pull requests and ordinary pushes run checks without publishing installers. v0.3.1 is the first updater-capable release; older versions require one manual upgrade before later stable releases can update in-app.
+See the [Windows guide](docs/WINDOWS.md) for setup, development, packaging, installation, and usage. Maintainers publish verified multi-platform packages through the [desktop release workflow](docs/RELEASE.md); macOS packages newer than v0.3.1 are signed and notarized, while Windows and preview architectures retain the limitations above. Pull requests and ordinary pushes run checks without publishing installers. v0.3.1 is the first updater-capable release; older versions require one manual upgrade before later stable releases can update in-app.
 
-The macOS package is not currently signed or notarized. Verify it against the SHA-256 file in the Release, drag AgentKib into Applications, and then remove its quarantine attributes:
+For the unsigned v0.3.1 and earlier macOS packages only, verify the DMG against its SHA-256 file, drag AgentKib into Applications, and then remove its quarantine attributes:
 
 ```bash
 xattr -cr /Applications/AgentKib.app

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentkib/desktop",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AgentKib",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "ai.agentkib",
   "build": {
     "beforeDevCommand": "pnpm quota:prepare && pnpm dev:web",

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -88,11 +88,37 @@ both that backup and the GitHub Secret breaks the update path for already
 installed clients. Tauri updater signatures verify update origin and integrity;
 they do not replace Apple notarization or Windows Authenticode signing.
 
+## macOS signing and notarization
+
+Published tags also require these GitHub Actions Secrets:
+
+- `APPLE_CERTIFICATE`: base64-encoded Developer ID Application `.p12` file.
+- `APPLE_CERTIFICATE_PASSWORD`: password used when exporting the `.p12` file.
+- `APPLE_SIGNING_IDENTITY`: full Developer ID Application identity.
+- `APPLE_TEAM_ID`: Apple Developer team ID.
+- `APPLE_API_ISSUER`, `APPLE_API_KEY`, and `APPLE_API_PRIVATE_KEY`: App Store
+  Connect team API credentials used only for notarization.
+
+The macOS jobs write the API private key to an owner-only temporary file, pass
+its path to Tauri, and remove it after the build. Tauri signs the application,
+submits it to Apple, waits for approval, and staples the notarization ticket.
+The workflow then verifies the Developer ID authority, team identifier,
+stapled ticket, and Gatekeeper assessment before staging release assets. A
+missing credential or failed verification prevents the Release from being
+published.
+
+The `.p12`, its password, and the App Store Connect `.p8` key must be backed up
+outside GitHub and shared only with authorized release maintainers. Rotate or
+revoke credentials deliberately; revoking them immediately blocks new macOS
+releases, but does not invalidate packages that were already signed and
+notarized.
+
 ## Preview limitations
 
-Release packages are unsigned development previews. They do not include macOS
-notarization, Windows code signing, MSI packages, or a macOS universal binary.
-macOS Gatekeeper and Windows SmartScreen may therefore display warnings.
+Releases newer than v0.3.1 include signed and notarized macOS packages. v0.3.1
+and earlier remain unsigned historical packages. Windows packages are still
+not Authenticode-signed, and the project does not yet provide MSI packages or a
+macOS universal binary. Windows SmartScreen may therefore display warnings.
 
 v0.3.1 is the first updater-capable release. Clients older than v0.3.1 require
 one manual upgrade; later stable releases can be installed in-app on macOS,
@@ -100,9 +126,9 @@ Windows, and Linux AppImage. DEB and RPM installations check for updates but
 continue through the GitHub Release page so their system package state is not
 modified behind the package manager.
 
-After verifying the downloaded DMG against its `.sha256` file and copying
-AgentKib into Applications, macOS users must currently remove the quarantine
-attributes before opening the app:
+For v0.3.1 and earlier only, after verifying the downloaded DMG against its
+`.sha256` file and copying AgentKib into Applications, macOS users must remove
+the quarantine attributes before opening the app:
 
 ```bash
 xattr -cr /Applications/AgentKib.app


### PR DESCRIPTION
## Summary

- 将应用、Tauri 和 Rust 工作区版本统一升级到 `0.3.2`
- 正式标签发布时使用 Developer ID 对 macOS 应用签名并提交 Apple 公证
- 发布前验证签名身份、Team ID、公证票据和 Gatekeeper 接受状态
- 手动构建继续保持无签名且不注入发布密钥，并更新 README 与发布文档

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm build`（`@agentkib/desktop@0.3.2`）
- `cargo check --workspace`（全部 workspace crate 为 `0.3.2`）
- `actionlint .github/workflows/release-desktop.yml`
- `git diff --check`
- 本机真实签名与 Apple 公证通过（Accepted），`codesign`、`stapler validate`、`spctl` 均通过

## Notes

- 合并后可直接创建 `v0.3.2` 标签，验证 CI 签名、公证、Release 产物和从旧版本应用内升级的完整链路。
- PR 构建不会读取 Apple 发布 Secrets；首个正式标签将验证 CI 中的 P12 导入与公证链路。