### PR TITLE
修复跨平台 Tabs 滚动条显示问题

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -332,6 +332,12 @@ button {
   background: var(--card);
   padding: 0.25rem;
   box-shadow: 0 1px 2px color-mix(in srgb, var(--foreground) 5%, transparent);
+  overflow-y: hidden;
+  scrollbar-width: none;
+}
+
+.segmented-control::-webkit-scrollbar {
+  display: none;
 }
 
 .segmented-control-item {


### PR DESCRIPTION
## 变更内容

- 隐藏 Tabs 在 Windows/macOS WebView 中出现的原生水平和垂直滚动条
- 保留内容溢出时的横向滚动能力
- 禁止垂直溢出，避免 Tabs 高度被撑开

## 验证

- `pnpm --filter @agentkib/desktop typecheck`
- `pnpm test`
- 11 个测试文件、58 个测试全部通过
- 本地预览确认 scrollbar 已隐藏