### PR TITLE
ci(release): 提高发布草稿解析可靠性

### DIFF
--- a/.github/scripts/resolve-draft-release.mjs
+++ b/.github/scripts/resolve-draft-release.mjs
@@ -1,0 +1,79 @@
+import { pathToFileURL } from "node:url";
+
+const retryDelaysMs = [1_000, 2_000, 4_000, 8_000, 12_000, 18_000];
+
+function validateDraftRelease(release, { tag, expectedSha }) {
+  if (release.tag_name !== tag) {
+    throw new Error(`Release tag ${release.tag_name ?? "<missing>"} does not match ${tag}`);
+  }
+  if (release.target_commitish !== expectedSha) {
+    throw new Error(
+      `Release ${tag} targets ${release.target_commitish ?? "<missing>"}, expected ${expectedSha}`,
+    );
+  }
+  if (release.draft !== true) {
+    throw new Error(`Release ${tag} is already public; refusing to overwrite it`);
+  }
+  if (!Number.isInteger(release.id) || release.id <= 0) {
+    throw new Error(`Release ${tag} does not have a valid numeric ID`);
+  }
+  return release;
+}
+
+export async function resolveDraftRelease({
+  load,
+  tag,
+  expectedSha,
+  delays = retryDelaysMs,
+  sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+}) {
+  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
+    const release = await load();
+    if (release) return validateDraftRelease(release, { tag, expectedSha });
+    if (attempt < delays.length) await sleep(delays[attempt]);
+  }
+  throw new Error(`Timed out waiting for draft release ${tag}`);
+}
+
+export async function loadReleaseByTag({ repository, tag, token, request = fetch }) {
+  const response = await request(
+    `https://api.github.com/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "agentkib-release-workflow",
+      },
+    },
+  );
+  if (response.status === 404) return undefined;
+  if (!response.ok) {
+    throw new Error(`GitHub release lookup failed with HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+async function main() {
+  const repository = process.env.GITHUB_REPOSITORY;
+  const tag = process.env.RELEASE_TAG;
+  const expectedSha = process.env.RELEASE_SHA;
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  if (!repository || !tag || !expectedSha || !token) {
+    throw new Error("GITHUB_REPOSITORY, RELEASE_TAG, RELEASE_SHA, and GH_TOKEN are required");
+  }
+
+  const load = () => loadReleaseByTag({ repository, tag, token });
+  const release = process.argv.includes("--wait")
+    ? await resolveDraftRelease({ load, tag, expectedSha })
+    : await load();
+  if (!release) return;
+  process.stdout.write(`${JSON.stringify(validateDraftRelease(release, { tag, expectedSha }))}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/resolve-draft-release.test.mjs
+++ b/.github/scripts/resolve-draft-release.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { loadReleaseByTag, resolveDraftRelease } from "./resolve-draft-release.mjs";
+
+const expected = {
+  id: 42,
+  tag_name: "v0.4.0",
+  target_commitish: "release-sha",
+  draft: true,
+};
+
+test("resolves a draft release immediately", async () => {
+  const release = await resolveDraftRelease({
+    load: async () => expected,
+    tag: "v0.4.0",
+    expectedSha: "release-sha",
+    delays: [],
+  });
+  assert.equal(release.id, 42);
+});
+
+test("retries a temporarily invisible draft release", async () => {
+  const responses = [undefined, undefined, expected];
+  const waits = [];
+  const release = await resolveDraftRelease({
+    load: async () => responses.shift(),
+    tag: "v0.4.0",
+    expectedSha: "release-sha",
+    delays: [10, 20],
+    sleep: async (milliseconds) => waits.push(milliseconds),
+  });
+  assert.equal(release.id, 42);
+  assert.deepEqual(waits, [10, 20]);
+});
+
+test("rejects mismatched, public, and invalid releases", async () => {
+  for (const release of [
+    { ...expected, tag_name: "v0.4.1" },
+    { ...expected, target_commitish: "other-sha" },
+    { ...expected, draft: false },
+    { ...expected, id: "42" },
+  ]) {
+    await assert.rejects(
+      resolveDraftRelease({
+        load: async () => release,
+        tag: "v0.4.0",
+        expectedSha: "release-sha",
+        delays: [],
+      }),
+    );
+  }
+});
+
+test("times out after the bounded retry schedule", async () => {
+  let attempts = 0;
+  await assert.rejects(
+    resolveDraftRelease({
+      load: async () => {
+        attempts += 1;
+        return undefined;
+      },
+      tag: "v0.4.0",
+      expectedSha: "release-sha",
+      delays: [1, 2, 3],
+      sleep: async () => undefined,
+    }),
+    /Timed out/,
+  );
+  assert.equal(attempts, 4);
+});
+
+test("treats GitHub 404 as not yet visible", async () => {
+  const missing = await loadReleaseByTag({
+    repository: "starroyhq/agentkib",
+    tag: "v0.4.0",
+    token: "test-token",
+    request: async () => ({ status: 404, ok: false }),
+  });
+  assert.equal(missing, undefined);
+});

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -181,8 +181,8 @@ jobs:
             fi
           done
 
-      - name: Test updater manifest generator
-        run: node --test .github/scripts/build-updater-manifest.test.mjs
+      - name: Test release scripts
+        run: node --test .github/scripts/*.test.mjs
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -692,20 +692,10 @@ jobs:
 
       - name: Prepare draft release
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-
-          find_release() {
-            gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
-              | jq -s --arg tag "$RELEASE_TAG" '
-                  add
-                  | map(select(.tag_name == $tag))
-                  | if length > 1 then error("multiple releases found for tag " + $tag)
-                    elif length == 1 then .[0]
-                    else empty
-                    end
-                '
-          }
 
           remote_tag_sha=$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')
           if [[ "$remote_tag_sha" != "$RELEASE_SHA" ]]; then
@@ -713,12 +703,8 @@ jobs:
             exit 1
           fi
 
-          release_json=$(find_release)
+          release_json=$(node .github/scripts/resolve-draft-release.mjs)
           if [[ -n "$release_json" ]]; then
-            if [[ "$(jq -r '.draft' <<<"$release_json")" != true ]]; then
-              echo "Release $RELEASE_TAG is already public; refusing to overwrite it" >&2
-              exit 1
-            fi
             echo "Resuming existing draft release $RELEASE_TAG"
           else
             release_notes=$(
@@ -743,7 +729,7 @@ jobs:
               create_args+=(--prerelease)
             fi
             gh "${create_args[@]}"
-            release_json=$(find_release)
+            release_json=$(node .github/scripts/resolve-draft-release.mjs --wait)
           fi
 
           release_id=$(jq -r '.id // empty' <<<"$release_json")

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 </p>
 
 > [!WARNING]
-> AgentKib 仍处于开发预览阶段，[Releases](https://github.com/starroyhq/agentkib/releases) 提供的安装包尚未签名。本地数据格式和部分功能可能继续调整；macOS Gatekeeper 和 Windows SmartScreen 可能显示安全提醒。
-> AgentKib is a development preview. Installers on [Releases](https://github.com/starroyhq/agentkib/releases) are currently unsigned, and local data formats and some features may still change. macOS Gatekeeper and Windows SmartScreen may show warnings.
+> AgentKib 仍处于开发预览阶段。本地数据格式和部分功能可能继续调整；macOS v0.3.2 及以后版本已签名并通过 Apple 公证，Windows 安装包仍未进行 Authenticode 签名。
+> AgentKib is a development preview. Local data formats and some features may still change. macOS releases starting with v0.3.2 are signed and notarized by Apple; Windows installers are not yet Authenticode-signed.
 
 ## 简体中文
 
@@ -63,7 +63,7 @@ AgentKib 会读取本机已有的工作区和配置，让你在一个界面里�
 - Windows 11：x64 的 `.exe`；ARM64 安装包仍为 Preview
 - Linux：Ubuntu 的 `.deb` 或 AppImage、Fedora 的 `.rpm`；ARM64 安装包仍为 Preview
 
-当前安装包尚未进行 macOS 公证或 Windows 代码签名，请只使用官方 Release 中的文件并核对对应 `.sha256`。macOS 的额外安装步骤见下方[平台状态](#平台状态)。
+macOS v0.3.2 及以后版本已签名并通过 Apple 公证；Windows 安装包仍未进行 Authenticode 签名。请只使用官方 Release 中的文件并核对对应 `.sha256`。历史 macOS 版本的额外安装步骤见下方[平台状态](#平台状态)。
 
 **v0.3.1 是首个支持应用内更新的版本。** 从更早版本升级时，需要先手动安装 v0.3.1 或更新版本；之后可在“设置 → 常规”中检查更新。macOS、Windows 和 Linux AppImage 支持应用内下载安装，DEB/RPM 会打开 Release 页面交由系统包管理方式更新。
 
@@ -131,11 +131,11 @@ AgentKib 会区分“已安装”和“只发现了卸载后留下的本地数�
 | Fedora x64 | PR 验证平台代码；发布工作流构建并验证 `.rpm` |
 | Windows ARM64 / Linux ARM64 | Preview；发布工作流生成并验证预览包 |
 
-Windows 的完整环境、启动、打包和安装说明见 [Windows 指南](docs/WINDOWS.md)。维护者按 [桌面发布流程](docs/RELEASE.md) 推送版本标签后，CI 会构建、校验并发布未签名的多平台预览包；PR 和普通分支 push 只运行检查，不发布安装包。开发和验证命令见文末的[开发说明](#development)。
+Windows 的完整环境、启动、打包和安装说明见 [Windows 指南](docs/WINDOWS.md)。维护者按 [桌面发布流程](docs/RELEASE.md) 推送版本标签后，CI 会构建并校验多平台预览包，对 macOS 包完成签名和公证后再发布；PR 和普通分支 push 只运行检查，不发布安装包。开发和验证命令见文末的[开发说明](#development)。
 
 安装包与校验文件发布在 [Releases](https://github.com/starroyhq/agentkib/releases)，问题反馈请前往 [GitHub Issues](https://github.com/starroyhq/agentkib/issues)。v0.3.1 是首个包含更新器的版本；更早版本需先手动升级，此后的正式版本可按上文所述在应用内检查更新。
 
-macOS 安装包目前尚未签名和公证。请先核对 Release 中的 SHA-256 校验文件，将 AgentKib 拖入“应用程序”后，再执行以下命令解除隔离属性：
+macOS v0.3.2 及以后版本已签名并通过 Apple 公证，可在核对 SHA-256 后将 AgentKib 拖入“应用程序”并正常打开。只有使用 v0.3.1 及更早的历史包时，才需要执行以下命令解除隔离属性：
 
 ```bash
 xattr -cr /Applications/AgentKib.app
@@ -292,4 +292,4 @@ pnpm typecheck
 pnpm build
 ```
 
-AgentKib is a development preview. Unsigned preview installers and checksums are published on [Releases](https://github.com/starroyhq/agentkib/releases); macOS Gatekeeper and Windows SmartScreen may show warnings. For feedback, use [GitHub Issues](https://github.com/starroyhq/agentkib/issues).
+AgentKib is a development preview. Checksums are published with every package on [Releases](https://github.com/starroyhq/agentkib/releases). macOS releases starting with v0.3.2 are signed and notarized by Apple; Windows installers remain unsigned and may trigger SmartScreen. For feedback, use [GitHub Issues](https://github.com/starroyhq/agentkib/issues).

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -45,9 +45,11 @@ gh workflow run release-desktop.yml --ref main -f release_tag=vX.Y.Z
 ```
 
 The retry rebuilds every platform, resumes an existing draft, and replaces
-same-named draft assets. It refuses to overwrite a release that is already
-public. A product-code fix requires a new version and tag rather than moving an
-existing tag. Workflow artifacts remain available for diagnosing failed builds.
+same-named draft assets. Draft lookup uses the release-by-tag API with a bounded
+retry window because a newly created draft can be briefly unavailable through
+the GitHub API. It refuses to overwrite a release that is already public. A
+product-code fix requires a new version and tag rather than moving an existing
+tag. Workflow artifacts remain available for diagnosing failed builds.
 
 ## Build artifacts without publishing
 


### PR DESCRIPTION
## Summary
- poll the release-by-tag API with bounded backoff after creating a draft
- validate draft tag, target commit, state, and ID with focused tests
- align README and release docs with signed and notarized macOS packages since v0.3.2

## Validation
- `pnpm exec oxfmt --check .github/scripts/*.mjs`
- `node --test .github/scripts/*.test.mjs`
- `git diff --check`

Part 1 of the AgentKib v0.4.0 delivery sequence.