### PR TITLE
chore: 准备 v0.4.0 Beta 验收与发布

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Report a reproducible AgentKib problem
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve AgentKib. Do not include API keys, tokens, cookies, complete transcripts, or other sensitive project content.
+  - type: input
+    id: version
+    attributes:
+      label: AgentKib version
+      description: Find this in Settings → General.
+      placeholder: 0.4.0
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Platform and architecture
+      placeholder: macOS 15.6 arm64 / Windows 11 x64 / Ubuntu 24.04 x64
+    validations:
+      required: true
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Related Agent
+      options:
+        - None or not sure
+        - Codex
+        - Claude Code
+        - Cursor
+        - OpenClaw
+        - Hermes
+        - DeepSeek Harness
+        - Multiple Agents
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Use the smallest reproducible sequence and replace private paths or names with placeholders.
+      placeholder: |
+        1. Open …
+        2. Click …
+        3. Observe …
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Additional diagnostics
+      description: Optional. Include only redacted error text or screenshots; do not upload full transcripts, credentials, or private configuration files.
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Sensitive data check
+      options:
+        - label: I removed secrets, cookies, full transcripts, and private project content.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: AgentKib documentation
+    url: https://github.com/starroyhq/agentkib#readme
+    about: Read the installation, privacy, and platform notes before filing an issue.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Describe a real workflow problem AgentKib could solve
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Start with the problem and workflow rather than a proposed implementation. Do not include keys, cookies, full transcripts, or private project content.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is difficult, repetitive, unsafe, or currently impossible?
+    validations:
+      required: true
+  - type: textarea
+    id: scenario
+    attributes:
+      label: Usage scenario
+      description: Who encounters this, with which Agent or workspace, and what are they trying to finish?
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the result that would make the workflow successful.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Current workaround
+      description: Optional. How do you handle this today?
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Sensitive data check
+      options:
+        - label: I removed secrets, cookies, full transcripts, and private project content.
+          required: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentkib-adapters"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-cli"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-core",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-conversations"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-core"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-desktop"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-conversations",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-discovery"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-gateways"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-git"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-insights"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-mcp"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-platform"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "hex",
  "libc",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-quota"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-storage"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "agentkib-platform",
  "chrono",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-store"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "agentkib-conversations",
  "agentkib-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ AgentKib 会区分“已安装”和“只发现了卸载后留下的本地数�
 
 Windows 的完整环境、启动、打包和安装说明见 [Windows 指南](docs/WINDOWS.md)。维护者按 [桌面发布流程](docs/RELEASE.md) 推送版本标签后，CI 会构建并校验多平台预览包，对 macOS 包完成签名和公证后再发布；PR 和普通分支 push 只运行检查，不发布安装包。开发和验证命令见文末的[开发说明](#development)。
 
-安装包与校验文件发布在 [Releases](https://github.com/starroyhq/agentkib/releases)，问题反馈请前往 [GitHub Issues](https://github.com/starroyhq/agentkib/issues)。v0.3.1 是首个包含更新器的版本；更早版本需先手动升级，此后的正式版本可按上文所述在应用内检查更新。
+安装包与校验文件发布在 [Releases](https://github.com/starroyhq/agentkib/releases)，问题反馈请前往 [GitHub Issues](https://github.com/starroyhq/agentkib/issues)，发布候选版本按 [Beta 验收指南](docs/BETA.md) 检查。v0.3.1 是首个包含更新器的版本；更早版本需先手动升级，此后的正式版本可按上文所述在应用内检查更新。
 
 macOS v0.3.2 及以后版本已签名并通过 Apple 公证，可在核对 SHA-256 后将 AgentKib 拖入“应用程序”并正常打开。只有使用 v0.3.1 及更早的历史包时，才需要执行以下命令解除隔离属性：
 
@@ -292,4 +292,4 @@ pnpm typecheck
 pnpm build
 ```
 
-AgentKib is a development preview. Checksums are published with every package on [Releases](https://github.com/starroyhq/agentkib/releases). macOS releases starting with v0.3.2 are signed and notarized by Apple; Windows installers remain unsigned and may trigger SmartScreen. For feedback, use [GitHub Issues](https://github.com/starroyhq/agentkib/issues).
+AgentKib is a development preview. Checksums are published with every package on [Releases](https://github.com/starroyhq/agentkib/releases). macOS releases starting with v0.3.2 are signed and notarized by Apple; Windows installers remain unsigned and may trigger SmartScreen. For feedback, use [GitHub Issues](https://github.com/starroyhq/agentkib/issues); release candidates follow the [Beta acceptance guide](docs/BETA.md).

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentkib/desktop",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AgentKib",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "identifier": "ai.agentkib",
   "build": {
     "beforeDevCommand": "pnpm quota:prepare && pnpm dev:web",

--- a/docs/BETA.md
+++ b/docs/BETA.md
@@ -2,7 +2,15 @@
 
 This guide is for maintainers and testers validating a release candidate. AgentKib does not automatically collect telemetry, upload diagnostics, or send workspace and conversation content. Feedback is submitted deliberately through [GitHub Issues](https://github.com/starroyhq/agentkib/issues).
 
-## Five-minute core path
+## Before tagging: candidate checks
+
+Run the artifact-only desktop workflow against the release commit and use its
+packages for the checks in this section. These candidate artifacts validate the
+application behavior and packaging shape, but they are not the final release
+artifacts: macOS candidates are unsigned, and updater signatures and
+`latest.json` are not generated until the tagged release run.
+
+### Five-minute core path
 
 Use a disposable or backed-up workspace. Do not use production secrets for the first pass.
 
@@ -14,7 +22,21 @@ Use a disposable or backed-up workspace. Do not use production secrets for the f
 
 Applying a ChangeSet is optional. A tester may reject it or close the getting-started guide without changing project files.
 
-## Platform installation checks
+### Candidate platform checks
+
+- [ ] Confirm every expected platform artifact is present and its SHA-256 file verifies successfully.
+- [ ] Confirm the package launches on representative test systems, accounting for the unsigned macOS candidate limitation.
+- [ ] Complete the five-minute core path on at least one supported platform.
+
+## After publishing: release-asset checks
+
+Create the immutable version tag only after the candidate checks pass. The
+tagged workflow builds a different set of release artifacts with updater
+signatures and signed/notarized macOS packages. Complete every check below
+against the assets attached to the published GitHub Release, not against the
+artifact-only candidate run.
+
+### Platform installation checks
 
 ### macOS
 
@@ -34,7 +56,7 @@ Applying a ChangeSet is optional. A tester may reject it or close the getting-st
 - [ ] Confirm executable permissions and desktop integration for the AppImage.
 - [ ] Confirm DEB/RPM upgrades remain under the system package manager rather than the in-app installer.
 
-## Update checks
+### Update checks
 
 - [ ] Start from the latest supported stable version and use Settings → General → Check for updates.
 - [ ] Confirm the displayed version and release notes match the target GitHub Release.
@@ -42,7 +64,7 @@ Applying a ChangeSet is optional. A tester may reject it or close the getting-st
 - [ ] For DEB/RPM, confirm AgentKib opens the matching Release page instead of replacing the system package.
 - [ ] After restart, confirm workspaces, preferences, local indexes, and the getting-started acknowledgement remain intact.
 
-## Rollback checks
+### Rollback checks
 
 The updater does not perform downgrades. To test rollback:
 

--- a/docs/BETA.md
+++ b/docs/BETA.md
@@ -1,0 +1,68 @@
+# AgentKib Beta acceptance guide
+
+This guide is for maintainers and testers validating a release candidate. AgentKib does not automatically collect telemetry, upload diagnostics, or send workspace and conversation content. Feedback is submitted deliberately through [GitHub Issues](https://github.com/starroyhq/agentkib/issues).
+
+## Five-minute core path
+
+Use a disposable or backed-up workspace. Do not use production secrets for the first pass.
+
+- [ ] Install AgentKib and confirm that it opens without bypass commands or elevated privileges.
+- [ ] Add an authorized scan directory and confirm that at least one expected workspace appears.
+- [ ] Open that workspace, run Context Doctor, and review its evidence paths and severity counts.
+- [ ] If repairable issues exist, generate a ChangeSet, inspect every diff, and apply it. If no repairable issue exists, record the workspace as healthy.
+- [ ] Return to Context Doctor and confirm that AgentKib automatically reruns the diagnosis and reports the remaining repairable count.
+
+Applying a ChangeSet is optional. A tester may reject it or close the getting-started guide without changing project files.
+
+## Platform installation checks
+
+### macOS
+
+- [ ] Test the matching Apple Silicon or Intel DMG.
+- [ ] Confirm Gatekeeper opens the app normally. Releases from v0.3.2 onward must be Developer ID signed and Apple notarized.
+- [ ] Confirm the installed app reports the expected version in Settings → General.
+
+### Windows
+
+- [ ] Test the x64 installer; treat ARM64 packages as Preview.
+- [ ] Record any SmartScreen prompt. Windows installers are not yet Authenticode signed.
+- [ ] Confirm uninstall and reinstall do not silently delete AgentKib's local data.
+
+### Linux
+
+- [ ] Test the x64 AppImage and the package appropriate for the distribution; ARM64 packages are Preview.
+- [ ] Confirm executable permissions and desktop integration for the AppImage.
+- [ ] Confirm DEB/RPM upgrades remain under the system package manager rather than the in-app installer.
+
+## Update checks
+
+- [ ] Start from the latest supported stable version and use Settings → General → Check for updates.
+- [ ] Confirm the displayed version and release notes match the target GitHub Release.
+- [ ] For macOS, Windows, and Linux AppImage, complete download, signature verification, installation, and restart.
+- [ ] For DEB/RPM, confirm AgentKib opens the matching Release page instead of replacing the system package.
+- [ ] After restart, confirm workspaces, preferences, local indexes, and the getting-started acknowledgement remain intact.
+
+## Rollback checks
+
+The updater does not perform downgrades. To test rollback:
+
+1. Back up the AgentKib data directory shown in Settings before changing versions.
+2. Close AgentKib and install the previous package from its immutable GitHub Release.
+3. Open the previous version and confirm it can read the existing workspaces and preferences.
+4. If a regression affects local indexes, preserve the backup and report the exact upgrade and rollback versions rather than deleting evidence.
+
+Never move or overwrite a published tag. Release defects use a new patch version, such as `v0.4.1`.
+
+## Reporting feedback safely
+
+Use the repository's Bug report or Feature request form. Include the AgentKib version, operating system and architecture, related Agent, and minimal reproduction steps.
+
+Before submitting:
+
+- Replace user names, workspace names, and absolute paths with neutral placeholders.
+- Remove API keys, tokens, Authorization or Cookie values, environment secrets, and private repository URLs.
+- Do not attach complete Codex or Claude Code transcripts.
+- Crop screenshots to the relevant UI and inspect visible terminal, path, and notification content.
+- Prefer a small disposable reproduction over uploading real project configuration.
+
+AgentKib does not upload this information on your behalf. The tester controls exactly what is shared in GitHub Issues.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -10,7 +10,9 @@ branch pushes run platform checks but do not publish installers.
    `apps/desktop/package.json`, and
    `apps/desktop/src-tauri/tauri.conf.json`.
 2. Merge the version change into `main` and make sure the required checks pass.
-3. Create an annotated version tag on that `main` commit and push only the tag:
+3. Run the workflow manually without `release_tag`, then complete the
+   [Beta acceptance guide](BETA.md) against the candidate artifacts.
+4. Create an annotated version tag on that `main` commit and push only the tag:
 
    ```bash
    git switch main
@@ -19,7 +21,7 @@ branch pushes run platform checks but do not publish installers.
    git push origin v0.1.0
    ```
 
-4. Wait for every job in **Desktop Package Artifacts** to pass. The workflow
+5. Wait for every job in **Desktop Package Artifacts** to pass. The workflow
    creates a draft GitHub Release only after all platform builds complete. It
    verifies the complete asset manifest, SHA-256 checksums, updater signatures,
    and `latest.json`, uploads the files, checks their remote names and sizes,

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -11,7 +11,10 @@ branch pushes run platform checks but do not publish installers.
    `apps/desktop/src-tauri/tauri.conf.json`.
 2. Merge the version change into `main` and make sure the required checks pass.
 3. Run the workflow manually without `release_tag`, then complete the
-   [Beta acceptance guide](BETA.md) against the candidate artifacts.
+   pre-release parts of the [Beta acceptance guide](BETA.md) against the
+   candidate artifacts. Artifact-only runs intentionally produce unsigned
+   macOS previews and omit updater signatures and `latest.json`; they cannot
+   validate Gatekeeper, notarization, or the end-to-end updater path.
 4. Create an annotated version tag on that `main` commit and push only the tag:
 
    ```bash
@@ -26,6 +29,10 @@ branch pushes run platform checks but do not publish installers.
    verifies the complete asset manifest, SHA-256 checksums, updater signatures,
    and `latest.json`, uploads the files, checks their remote names and sizes,
    and then publishes the release.
+6. Complete the release-only signing, notarization, installation, and updater
+   checks in the [Beta acceptance guide](BETA.md) against the published,
+   immutable Release assets. If a defect is found, publish a new patch version;
+   do not move or replace the tag.
 
 Do not create an empty GitHub Release before pushing the tag. Stable SemVer
 tags such as `v0.1.0` become the latest release. Tags containing a prerelease
@@ -58,6 +65,12 @@ tag. Workflow artifacts remain available for diagnosing failed builds.
 To create packages for a branch without creating a GitHub Release, open
 **Actions**, select **Desktop Package Artifacts**, choose **Run workflow**, pick
 the branch, and leave `release_tag` empty.
+
+These packages are intended for pre-release functional checks only. macOS
+artifacts from this path are unsigned previews, and the workflow does not
+create updater signatures or `latest.json`. Release signing, notarization, and
+end-to-end update checks must use the assets produced by the tagged release
+run.
 
 The run produces these downloadable workflow artifacts:
 


### PR DESCRIPTION
## 概要
- 增加 Bug 报告与功能建议 Issue Forms，并明确敏感信息脱敏要求
- 增加五分钟核心路径、平台安装、更新、回滚与反馈检查的 Beta 验收指南
- 在发布流程与 README 中链接验收指南
- 将 Cargo、Tauri 和桌面 package 版本统一升级到 `0.4.0`

## 验证
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `cargo fmt --all -- --check`
- 全新 `CARGO_TARGET_DIR`：`cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Issue Forms 通过 Ruby YAML 解析
- 三个版本源一致性校验
- `git diff --check`

## 备注
- 不含遥测、自动反馈、数据库或生产依赖变更
- `.idea/` 保持未跟踪，未包含在提交中
- 需在前两个 PR 合并并完成候选包验收后，才创建不可移动的 `v0.4.0` 标签