### PR TITLE
fix(ci): 修复发布草稿解析与重试

### DIFF
--- a/.github/scripts/resolve-draft-release.mjs
+++ b/.github/scripts/resolve-draft-release.mjs
@@ -36,18 +36,48 @@ export async function resolveDraftRelease({
 }
 
 export async function loadReleaseByTag({ repository, tag, token, request = fetch }) {
+  const headers = {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "agentkib-release-workflow",
+  };
   const response = await request(
     `https://api.github.com/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`,
-    {
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${token}`,
-        "X-GitHub-Api-Version": "2022-11-28",
-        "User-Agent": "agentkib-release-workflow",
-      },
-    },
+    { headers },
   );
-  if (response.status === 404) return undefined;
+  if (response.status === 404) {
+    let url = `https://api.github.com/repos/${repository}/releases?per_page=100`;
+    const visited = new Set();
+    const matches = [];
+
+    while (url) {
+      if (visited.has(url)) throw new Error("GitHub release pagination contains a loop");
+      visited.add(url);
+
+      const page = await request(url, { headers });
+      if (!page.ok) {
+        throw new Error(`GitHub release list failed with HTTP ${page.status}`);
+      }
+      const releases = await page.json();
+      if (!Array.isArray(releases)) {
+        throw new Error("GitHub release list returned an invalid response");
+      }
+      matches.push(...releases.filter((release) => release.tag_name === tag));
+
+      const link = page.headers?.get?.("link") ?? "";
+      url =
+        link
+          .split(",")
+          .map((part) => part.trim().match(/^<([^>]+)>;\s*rel="([^"]+)"$/))
+          .find((match) => match?.[2] === "next")?.[1] ?? "";
+    }
+
+    if (matches.length > 1) {
+      throw new Error(`Multiple GitHub releases use tag ${tag}`);
+    }
+    return matches[0];
+  }
   if (!response.ok) {
     throw new Error(`GitHub release lookup failed with HTTP ${response.status}`);
   }

--- a/.github/scripts/resolve-draft-release.test.mjs
+++ b/.github/scripts/resolve-draft-release.test.mjs
@@ -70,12 +70,71 @@ test("times out after the bounded retry schedule", async () => {
   assert.equal(attempts, 4);
 });
 
-test("treats GitHub 404 as not yet visible", async () => {
+test("falls back to the authenticated release list when drafts return 404", async () => {
+  const requests = [];
+  const release = await loadReleaseByTag({
+    repository: "starroyhq/agentkib",
+    tag: "v0.4.0",
+    token: "test-token",
+    request: async (url) => {
+      requests.push(url);
+      if (url.includes("/releases/tags/")) return { status: 404, ok: false };
+      return {
+        status: 200,
+        ok: true,
+        headers: { get: () => null },
+        json: async () => [expected],
+      };
+    },
+  });
+  assert.equal(release.id, 42);
+  assert.equal(requests.length, 2);
+});
+
+test("follows paginated release lists and returns undefined when the tag is absent", async () => {
+  const pages = [
+    {
+      status: 200,
+      ok: true,
+      headers: {
+        get: () => '<https://api.github.test/releases?page=2>; rel="next", <x>; rel="last"',
+      },
+      json: async () => [{ ...expected, tag_name: "v0.3.2" }],
+    },
+    {
+      status: 200,
+      ok: true,
+      headers: { get: () => null },
+      json: async () => [],
+    },
+  ];
   const missing = await loadReleaseByTag({
     repository: "starroyhq/agentkib",
     tag: "v0.4.0",
     token: "test-token",
-    request: async () => ({ status: 404, ok: false }),
+    request: async (url) =>
+      url.includes("/releases/tags/") ? { status: 404, ok: false } : pages.shift(),
   });
   assert.equal(missing, undefined);
+  assert.equal(pages.length, 0);
+});
+
+test("rejects duplicate draft tags returned by the release list", async () => {
+  await assert.rejects(
+    loadReleaseByTag({
+      repository: "starroyhq/agentkib",
+      tag: "v0.4.0",
+      token: "test-token",
+      request: async (url) => {
+        if (url.includes("/releases/tags/")) return { status: 404, ok: false };
+        return {
+          status: 200,
+          ok: true,
+          headers: { get: () => null },
+          json: async () => [expected, { ...expected, id: 43 }],
+        };
+      },
+    }),
+    /Multiple GitHub releases/,
+  );
 });

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -584,6 +584,7 @@ jobs:
       RELEASE_ASSETS_DIR: dist/github-release
       RELEASE_SHA: ${{ needs.preflight.outputs.release_sha }}
       RELEASE_TAG: ${{ needs.preflight.outputs.release_tag }}
+      RELEASE_WORKFLOW_SCRIPTS_DIR: .release-workflow-source/.github/scripts
       WORKFLOW_ARTIFACTS_DIR: dist/workflow-artifacts
 
     steps:
@@ -592,6 +593,18 @@ jobs:
         with:
           ref: ${{ needs.preflight.outputs.release_sha }}
           fetch-depth: 1
+
+      - name: Checkout release workflow helpers
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          path: .release-workflow-source
+          persist-credentials: false
+          sparse-checkout: .github/scripts
+
+      - name: Test release workflow helpers
+        shell: bash
+        run: node --test "$RELEASE_WORKFLOW_SCRIPTS_DIR"/*.test.mjs
 
       - name: Download platform artifacts
         uses: actions/download-artifact@v8
@@ -682,7 +695,7 @@ jobs:
             -f tag_name="$RELEASE_TAG" \
             -f target_commitish="$RELEASE_SHA" \
             --jq '.body' > "$notes_file"
-          node .github/scripts/build-updater-manifest.mjs \
+          node "$RELEASE_WORKFLOW_SCRIPTS_DIR/build-updater-manifest.mjs" \
             "$RELEASE_ASSETS_DIR" "$GITHUB_REPOSITORY" "$RELEASE_TAG" "$APP_VERSION" \
             "$published_at" "$notes_file"
           test -s "$RELEASE_ASSETS_DIR/latest.json"
@@ -703,7 +716,7 @@ jobs:
             exit 1
           fi
 
-          release_json=$(node .github/scripts/resolve-draft-release.mjs)
+          release_json=$(node "$RELEASE_WORKFLOW_SCRIPTS_DIR/resolve-draft-release.mjs")
           if [[ -n "$release_json" ]]; then
             echo "Resuming existing draft release $RELEASE_TAG"
           else
@@ -729,7 +742,7 @@ jobs:
               create_args+=(--prerelease)
             fi
             gh "${create_args[@]}"
-            release_json=$(node .github/scripts/resolve-draft-release.mjs --wait)
+            release_json=$(node "$RELEASE_WORKFLOW_SCRIPTS_DIR/resolve-draft-release.mjs" --wait)
           fi
 
           release_id=$(jq -r '.id // empty' <<<"$release_json")

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -54,11 +54,14 @@ gh workflow run release-desktop.yml --ref main -f release_tag=vX.Y.Z
 ```
 
 The retry rebuilds every platform, resumes an existing draft, and replaces
-same-named draft assets. Draft lookup uses the release-by-tag API with a bounded
-retry window because a newly created draft can be briefly unavailable through
-the GitHub API. It refuses to overwrite a release that is already public. A
-product-code fix requires a new version and tag rather than moving an existing
-tag. Workflow artifacts remain available for diagnosing failed builds.
+same-named draft assets. GitHub's release-by-tag API can omit draft releases,
+so draft lookup falls back to the authenticated, paginated Releases list and
+uses a bounded retry window. Manual retries build the immutable tagged source
+but use the reviewed release helpers from the selected workflow revision. The
+workflow refuses duplicate tags and will not overwrite a release that is
+already public. A product-code fix requires a new version and tag rather than
+moving an existing tag. Workflow artifacts remain available for diagnosing
+failed builds.
 
 ## Build artifacts without publishing
 


### PR DESCRIPTION
## Summary

- fall back to the authenticated paginated Releases API when GitHub omits drafts from the release-by-tag endpoint
- reject duplicate tags, mismatched targets, and public releases before uploading assets
- run publish helpers from the workflow revision so an immutable existing tag can be retried after a CI-only fix
- document the safe retry behavior

## Incident

The v0.4.0 release run built and validated all seven platforms, then stopped safely because the draft release remained invisible through the release-by-tag API. The draft is still private and empty; workflow artifacts remain available.

## Validation

- `node --test .github/scripts/*.test.mjs`
- real authenticated resolution of draft release `377621855`
- workflow YAML parse
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

After merge, retry with:

```bash
gh workflow run release-desktop.yml --ref main -f release_tag=v0.4.0
```