### PR TITLE
chore(release): 准备 v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentkib-adapters"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-core",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-conversations"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-desktop"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-conversations",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-discovery"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-gateways"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-git"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-insights"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -179,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-mcp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-platform"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "hex",
  "libc",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-quota"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -232,7 +232,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-storage"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agentkib-platform",
  "chrono",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-store"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "agentkib-conversations",
  "agentkib-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT"
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentkib/desktop",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "tauri dev --features dev-app --config src-tauri/tauri.dev.conf.json",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "AgentKib",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "ai.agentkib",
   "build": {
     "beforeDevCommand": "pnpm quota:prepare && pnpm dev:web",

--- a/apps/desktop/src/components/SidebarBrand.test.tsx
+++ b/apps/desktop/src/components/SidebarBrand.test.tsx
@@ -20,4 +20,9 @@ describe("SidebarBrand", () => {
 
     expect(screen.getByRole("button", { name: "AgentKib Dev" })).toBeTruthy();
   });
+
+  it("keeps the sidebar usable when storage is unavailable", () => {
+    expect(() => useAppStore.getState().setSidebarCollapsed(true)).not.toThrow();
+    expect(useAppStore.getState().sidebarCollapsed).toBe(true);
+  });
 });

--- a/apps/desktop/src/stores/app-store.ts
+++ b/apps/desktop/src/stores/app-store.ts
@@ -78,9 +78,23 @@ const resolve = <T>(value: Updater<T>, current: T): T =>
 const SIDEBAR_COLLAPSED_STORAGE_KEY = "agentkib.sidebar-collapsed";
 
 function initialSidebarCollapsed() {
-  return typeof localStorage !== "undefined"
-    ? localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === "true"
-    : false;
+  try {
+    return typeof localStorage?.getItem === "function"
+      ? localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === "true"
+      : false;
+  } catch {
+    return false;
+  }
+}
+
+function persistSidebarCollapsed(value: boolean) {
+  try {
+    if (typeof localStorage?.setItem === "function") {
+      localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, String(value));
+    }
+  } catch {
+    // Persisting this UI preference is best-effort in restricted webviews.
+  }
 }
 
 export const useAppStore = create<AppState & AppActions>((set) => ({
@@ -128,9 +142,7 @@ export const useAppStore = create<AppState & AppActions>((set) => ({
   setSidebarCollapsed: (value) =>
     set((state) => {
       const next = resolve(value, state.sidebarCollapsed);
-      if (typeof localStorage !== "undefined") {
-        localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, String(next));
-      }
+      persistSidebarCollapsed(next);
       return { sidebarCollapsed: next };
     }),
   setRuntime: (value) => set((state) => ({ runtime: resolve(value, state.runtime) })),


### PR DESCRIPTION
## 概要
- 修复受限 WebView 或测试环境中 localStorage 不可用时的侧栏状态初始化
- 将 Cargo、Tauri 和桌面 package 版本统一升级到 0.5.0

## 验证
- pnpm test
- pnpm typecheck
- pnpm build
- cargo fmt --all -- --check
- 全新 CARGO_TARGET_DIR 的 cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check
- Windows Checks 失败 Job 重跑通过