### PR TITLE
fix(desktop): prevent settings navigation flash

### DIFF
--- a/apps/desktop/src/components/AppSidebar.tsx
+++ b/apps/desktop/src/components/AppSidebar.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { useEffect, useId, useState, type ComponentType } from "react";
-import { Keyboard, Menu, PanelLeftClose, PanelLeftOpen, Settings } from "lucide-react";
+import { Keyboard, Menu, Settings } from "lucide-react";
 import { tr } from "../core/i18n";
 import { cn } from "@/lib/utils";
 import { SidebarBrand } from "./SidebarBrand";
@@ -20,23 +20,16 @@ export interface SidebarEntry<T extends string> {
   shortcut?: ShortcutId;
 }
 
-export function AppSidebar<T extends string>({
-  active,
-  entries,
-  onNavigate,
-  onSettings,
-  onBrandClick,
-  collapsed,
-  onCollapsedChange,
-}: {
+export function AppSidebar<T extends string>(props: {
   active: T;
   entries: SidebarEntry<T>[];
   onNavigate: (page: T) => void;
   onSettings: () => void;
   onBrandClick: () => void;
   collapsed: boolean;
-  onCollapsedChange: (collapsed: boolean) => void;
+  onCollapsedChange?: (collapsed: boolean) => void;
 }) {
+  const { active, entries, onNavigate, onSettings, onBrandClick, collapsed } = props;
   const [mobileOpen, setMobileOpen] = useState(false);
   const sidebarId = useId();
   const { openShortcutHelp } = useShortcutHelp();
@@ -54,11 +47,6 @@ export function AppSidebar<T extends string>({
   const navigate = (page: T) => {
     setMobileOpen(false);
     onNavigate(page);
-  };
-
-  const toggleCollapsed = () => {
-    const next = !collapsed;
-    onCollapsedChange(next);
   };
 
   return (
@@ -85,31 +73,6 @@ export function AppSidebar<T extends string>({
           onClick={() => setMobileOpen(false)}
         />
       )}
-      <div className="app-shell-header">
-        <Button
-          variant="bare"
-          size="content"
-          className="app-sidebar-collapse-button"
-          type="button"
-          aria-label={tr(collapsed ? "common.expandSidebar" : "common.collapseSidebar")}
-          aria-keyshortcuts={ariaShortcut(getShortcutDefinition("toggle-sidebar"), platform)}
-          aria-expanded={!collapsed}
-          data-collapsed={collapsed}
-          title={tr(collapsed ? "common.expandSidebar" : "common.collapseSidebar")}
-          onClick={toggleCollapsed}
-        >
-          <span className="app-sidebar-collapse-icon" aria-hidden="true">
-            <PanelLeftClose
-              className={cn("app-sidebar-collapse-icon-close", collapsed && "is-hidden")}
-              size={17}
-            />
-            <PanelLeftOpen
-              className={cn("app-sidebar-collapse-icon-open", !collapsed && "is-hidden")}
-              size={17}
-            />
-          </span>
-        </Button>
-      </div>
       <aside
         id={sidebarId}
         className={cn(

--- a/apps/desktop/src/features/app/AppShell.tsx
+++ b/apps/desktop/src/features/app/AppShell.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import { WindowToolbar } from "@/components/WindowToolbar";
+import {
+  ariaShortcut,
+  currentAppPlatform,
+  getShortcutDefinition,
+} from "@/core/keyboard-shortcuts";
+import { tr } from "@/core/i18n";
+import { cn } from "@/lib/utils";
+import { useAppStore } from "@/stores/app-store";
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
+
+const mainClassName =
+  "app-shell-main !col-start-2 !row-start-3 !flex !min-h-0 !min-w-0 !h-full !flex-col !overflow-hidden !text-sm";
+
+export function AppShellHeader() {
+  const sidebarCollapsed = useAppStore((state) => state.sidebarCollapsed);
+  const setSidebarCollapsed = useAppStore((state) => state.setSidebarCollapsed);
+  const platform = currentAppPlatform();
+
+  return (
+    <div className="app-shell-header">
+      <Button
+        variant="bare"
+        size="content"
+        className="app-sidebar-collapse-button"
+        type="button"
+        aria-label={tr(sidebarCollapsed ? "common.expandSidebar" : "common.collapseSidebar")}
+        aria-keyshortcuts={ariaShortcut(getShortcutDefinition("toggle-sidebar"), platform)}
+        aria-expanded={!sidebarCollapsed}
+        data-collapsed={sidebarCollapsed}
+        title={tr(sidebarCollapsed ? "common.expandSidebar" : "common.collapseSidebar")}
+        onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
+      >
+        <span className="app-sidebar-collapse-icon" aria-hidden="true">
+          <PanelLeftClose
+            className={cn("app-sidebar-collapse-icon-close", sidebarCollapsed && "is-hidden")}
+            size={17}
+          />
+          <PanelLeftOpen
+            className={cn("app-sidebar-collapse-icon-open", !sidebarCollapsed && "is-hidden")}
+            size={17}
+          />
+        </span>
+      </Button>
+    </div>
+  );
+}
+
+export function AppShell({
+  sidebar,
+  children,
+  mainClassName: additionalMainClassName,
+}: {
+  sidebar: ReactNode;
+  children: ReactNode;
+  mainClassName?: string;
+}) {
+  const sidebarCollapsed = useAppStore((state) => state.sidebarCollapsed);
+
+  return (
+    <div
+      className={cn(
+        "group app-shell !grid !h-full !w-full !min-h-0 !overflow-hidden",
+        sidebarCollapsed && "app-shell-sidebar-collapsed",
+      )}
+    >
+      <WindowToolbar />
+      <AppShellHeader />
+      {sidebar}
+      <main className={cn(mainClassName, additionalMainClassName)}>
+        <div className="page-scroll-container min-h-0 flex-1">
+          {children}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/app/AppShell.tsx
+++ b/apps/desktop/src/features/app/AppShell.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 
+import { useLocation } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
 import { WindowToolbar } from "@/components/WindowToolbar";
 import {
@@ -11,6 +12,7 @@ import { tr } from "@/core/i18n";
 import { cn } from "@/lib/utils";
 import { useAppStore } from "@/stores/app-store";
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { useEffect, useRef } from "react";
 
 const mainClassName =
   "app-shell-main !col-start-2 !row-start-3 !flex !min-h-0 !min-w-0 !h-full !flex-col !overflow-hidden !text-sm";
@@ -59,6 +61,14 @@ export function AppShell({
   mainClassName?: string;
 }) {
   const sidebarCollapsed = useAppStore((state) => state.sidebarCollapsed);
+  const locationKey = useLocation({ select: (location) => location.href });
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = 0;
+    }
+  }, [locationKey]);
 
   return (
     <div
@@ -71,7 +81,7 @@ export function AppShell({
       <AppShellHeader />
       {sidebar}
       <main className={cn(mainClassName, additionalMainClassName)}>
-        <div className="page-scroll-container min-h-0 flex-1">
+        <div ref={scrollContainerRef} className="page-scroll-container min-h-0 flex-1">
           {children}
         </div>
       </main>

--- a/apps/desktop/src/features/app/GlobalShell.tsx
+++ b/apps/desktop/src/features/app/GlobalShell.tsx
@@ -1,8 +1,7 @@
 import { Award, Bot, CircleAlert, FolderGit2, Gauge, Home, Library } from "lucide-react";
 import { Outlet } from "@tanstack/react-router";
 import { AppSidebar, type SidebarEntry } from "@/components/AppSidebar";
-import { WindowToolbar } from "@/components/WindowToolbar";
-import { cn } from "@/lib/utils";
+import { AppShell } from "./AppShell";
 import type { RefreshJobStatus } from "@/core/types";
 import type { GlobalPage } from "./app-route";
 import { useAppStore } from "@/stores/app-store";
@@ -43,13 +42,6 @@ export function GlobalShell({
   onSettings: () => void;
 }) {
   const sidebarCollapsed = useAppStore((state) => state.sidebarCollapsed);
-  const setSidebarCollapsed = useAppStore((state) => state.setSidebarCollapsed);
-  const shellClass = cn(
-    "group app-shell !grid !h-full !w-full !min-h-0 !overflow-hidden",
-    sidebarCollapsed && "app-shell-sidebar-collapsed",
-  );
-  const mainClass =
-    "app-shell-main !col-start-2 !row-start-3 !flex !min-h-0 !min-w-0 !h-full !flex-col !overflow-hidden !text-sm";
   const contentClass =
     "content !mx-auto !max-w-[1540px] !px-7 !pb-10 !pt-[14px] max-[900px]:!px-[18px]";
   const discoveryFailure = refreshJobs.find(
@@ -57,35 +49,32 @@ export function GlobalShell({
   );
 
   return (
-    <div className={shellClass}>
-      <WindowToolbar />
-      <AppSidebar
-        active={active}
-        collapsed={sidebarCollapsed}
-        entries={entries}
-        onNavigate={onNavigate}
-        onSettings={onSettings}
-        onBrandClick={() => onNavigate("home")}
-        onCollapsedChange={setSidebarCollapsed}
-      />
-      <main className={mainClass}>
-        <div className="page-scroll-container min-h-0 flex-1">
-          {message && (
-            <div className="mx-7 mt-3 flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
-              <CircleAlert size={17} />
-              {message}
-            </div>
-          )}
-          {active === "workspaces" && discoveryFailure?.error && (
-            <div className="mx-7 mt-3 flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
-              {discoveryFailure.error}
-            </div>
-          )}
-          <section className={cn(contentClass, "")}>
-            <Outlet />
-          </section>
+    <AppShell
+      sidebar={
+        <AppSidebar
+          active={active}
+          collapsed={sidebarCollapsed}
+          entries={entries}
+          onNavigate={onNavigate}
+          onSettings={onSettings}
+          onBrandClick={() => onNavigate("home")}
+        />
+      }
+    >
+      {message && (
+        <div className="mx-7 mt-3 flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          <CircleAlert size={17} />
+          {message}
         </div>
-      </main>
-    </div>
+      )}
+      {active === "workspaces" && discoveryFailure?.error && (
+        <div className="mx-7 mt-3 flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          {discoveryFailure.error}
+        </div>
+      )}
+      <section className={contentClass}>
+        <Outlet />
+      </section>
+    </AppShell>
   );
 }

--- a/apps/desktop/src/features/settings/SettingsSidebar.tsx
+++ b/apps/desktop/src/features/settings/SettingsSidebar.tsx
@@ -6,8 +6,6 @@ import {
   FolderSearch,
   Keyboard,
   Menu,
-  PanelLeftClose,
-  PanelLeftOpen,
   PlugZap,
   Settings,
   Settings2,
@@ -37,21 +35,15 @@ const sections: Array<{
   { id: "diagnostics", label: "settings.section.diagnostics", icon: Stethoscope },
 ];
 
-export function SettingsSidebar({
-  active,
-  onSelect,
-  onBack,
-  onSettings,
-  collapsed,
-  onCollapsedChange,
-}: {
+export function SettingsSidebar(props: {
   active: SettingsSection;
   onSelect: (section: SettingsSection) => void;
   onBack: () => void;
   onSettings: () => void;
   collapsed: boolean;
-  onCollapsedChange: (collapsed: boolean) => void;
+  onCollapsedChange?: (collapsed: boolean) => void;
 }) {
+  const { active, onSelect, onBack, onSettings, collapsed } = props;
   const [mobileOpen, setMobileOpen] = useState(false);
   const sidebarId = useId();
   const { openShortcutHelp } = useShortcutHelp();
@@ -69,11 +61,6 @@ export function SettingsSidebar({
   const select = (section: SettingsSection) => {
     setMobileOpen(false);
     onSelect(section);
-  };
-
-  const toggleCollapsed = () => {
-    const next = !collapsed;
-    onCollapsedChange(next);
   };
 
   return (
@@ -100,31 +87,6 @@ export function SettingsSidebar({
           onClick={() => setMobileOpen(false)}
         />
       )}
-      <div className="app-shell-header">
-        <Button
-          variant="bare"
-          size="content"
-          className="app-sidebar-collapse-button"
-          type="button"
-          aria-label={tr(collapsed ? "common.expandSidebar" : "common.collapseSidebar")}
-          aria-keyshortcuts={ariaShortcut(getShortcutDefinition("toggle-sidebar"), platform)}
-          aria-expanded={!collapsed}
-          data-collapsed={collapsed}
-          title={tr(collapsed ? "common.expandSidebar" : "common.collapseSidebar")}
-          onClick={toggleCollapsed}
-        >
-          <span className="app-sidebar-collapse-icon" aria-hidden="true">
-            <PanelLeftClose
-              className={cn("app-sidebar-collapse-icon-close", collapsed && "is-hidden")}
-              size={17}
-            />
-            <PanelLeftOpen
-              className={cn("app-sidebar-collapse-icon-open", !collapsed && "is-hidden")}
-              size={17}
-            />
-          </span>
-        </Button>
-      </div>
       <aside
         id={sidebarId}
         className={cn(

--- a/apps/desktop/src/routes/__root.tsx
+++ b/apps/desktop/src/routes/__root.tsx
@@ -1,16 +1,23 @@
-import { createRootRoute, Outlet } from "@tanstack/react-router";
+import { createRootRoute, Outlet, useNavigate, useSearch } from "@tanstack/react-router";
+import { CircleAlert } from "lucide-react";
 import { z } from "zod";
+import { AppSidebar, type SidebarEntry } from "@/components/AppSidebar";
 import type { SettingsSection } from "@/features/settings/SettingsSidebar";
+import { SettingsSidebar } from "@/features/settings/SettingsSidebar";
 import type { InsightsSection } from "@/features/insights/InsightsPage";
-import type { AgentKind } from "../core/types";
+import type { AgentKind, RefreshJobStatus } from "../core/types";
 import { AppRuntimeBridge } from "../features/app/AppRuntimeBridge";
-import { GlobalShell } from "../features/app/GlobalShell";
+import { AppShell } from "../features/app/AppShell";
+import type { GlobalPage, ParsedRoute } from "../features/app/app-route";
+import { cn } from "@/lib/utils";
 import { useAppNavigation } from "../features/app/useAppNavigation";
 import { ShortcutHelpDialog } from "../features/app/ShortcutHelpDialog";
 import { ShortcutHelpProvider } from "../features/app/ShortcutHelpContext";
 import { useAppShortcuts } from "../features/app/useAppShortcuts";
 import { useAppStore } from "../stores/app-store";
 import { useState } from "react";
+
+type SettingsSearch = { settingsSection?: SettingsSection };
 
 function RootLayout() {
   const {
@@ -42,10 +49,11 @@ function RootLayout() {
   return (
     <ShortcutHelpProvider openShortcutHelp={() => setShortcutHelpOpen(true)}>
       <AppRuntimeBridge />
-      {route.kind === "workspace" || route.kind === "settings" ? (
+      {route.kind === "workspace" ? (
         <Outlet />
       ) : (
-        <GlobalShell
+        <AppShellRouter
+          route={route}
           active={globalPage}
           entries={navigation}
           message={message}
@@ -56,6 +64,88 @@ function RootLayout() {
       )}
       <ShortcutHelpDialog open={shortcutHelpOpen} onOpenChange={setShortcutHelpOpen} />
     </ShortcutHelpProvider>
+  );
+}
+
+function AppShellRouter({
+  route,
+  active,
+  entries,
+  message,
+  refreshJobs,
+  onNavigate,
+  onSettings,
+}: {
+  route: Exclude<ParsedRoute, { kind: "workspace" }>;
+  active: GlobalPage;
+  entries: SidebarEntry<GlobalPage>[];
+  message: string;
+  refreshJobs: RefreshJobStatus[];
+  onNavigate: (page: GlobalPage) => void;
+  onSettings: () => void;
+}) {
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as SettingsSearch;
+  const sidebarCollapsed = useAppStore((state) => state.sidebarCollapsed);
+  const settingsSection = search.settingsSection ?? "general";
+  const isSettings = route.kind === "settings";
+  const discoveryFailure = refreshJobs.find(
+    (job) => job.kind === "discovery" && job.state === "failed",
+  );
+
+  const setSettingsSection = (section: SettingsSection) => {
+    void navigate({
+      to: "/settings",
+      search: (current) => ({ ...current, settingsSection: section }) as never,
+    });
+  };
+
+  const sidebar = isSettings ? (
+    <SettingsSidebar
+      active={settingsSection}
+      collapsed={sidebarCollapsed}
+      onSelect={setSettingsSection}
+      onBack={() => void navigate({ to: "/" })}
+      onSettings={() => setSettingsSection("general")}
+    />
+  ) : (
+    <AppSidebar
+      active={active}
+      collapsed={sidebarCollapsed}
+      entries={entries}
+      onNavigate={onNavigate}
+      onSettings={onSettings}
+      onBrandClick={() => onNavigate("home")}
+    />
+  );
+
+  return (
+    <AppShell
+      sidebar={sidebar}
+      mainClassName={isSettings ? `settings-section-${settingsSection}` : undefined}
+    >
+      {message && (
+        <div className="mx-7 mt-3 flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          <CircleAlert size={17} />
+          {message}
+        </div>
+      )}
+      {!isSettings && active === "workspaces" && discoveryFailure?.error && (
+        <div className="mx-7 mt-3 flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          {discoveryFailure.error}
+        </div>
+      )}
+      <section
+        className={cn(
+          isSettings
+            ? "mx-auto grid w-full max-w-[1180px] gap-5 px-7 pb-10 pt-[22px] max-[900px]:px-[18px]"
+            : "content mx-auto max-w-[1540px] px-7 pb-10 pt-[14px] max-[900px]:px-[18px]",
+          isSettings && settingsSection === "general" && "pt-4",
+        )}
+      >
+        <Outlet />
+      </section>
+    </AppShell>
   );
 }
 

--- a/apps/desktop/src/routes/settings.tsx
+++ b/apps/desktop/src/routes/settings.tsx
@@ -1,13 +1,10 @@
 import { createFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
-import { CircleAlert } from "lucide-react";
 import { open } from "@tauri-apps/plugin-dialog";
-import { cn } from "@/lib/utils";
 import { api } from "../core/api";
 import { GlobalSettings } from "@/features/settings/GlobalSettings";
 import { SettingsContentSkeleton } from "@/features/settings/SettingsSkeleton";
 import { localizeMessage, tr } from "../core/i18n";
-import { SettingsSidebar, type SettingsSection } from "@/features/settings/SettingsSidebar";
-import { WindowToolbar } from "@/components/WindowToolbar";
+import type { SettingsSection } from "@/features/settings/SettingsSidebar";
 import { useAppStore } from "../stores/app-store";
 import { useWorkspaceStore } from "@/features/workspace/workspace-store";
 import type { CloseBehavior, RuntimeInfo } from "../core/types";
@@ -19,8 +16,6 @@ function SettingsRoute() {
   const search = useSearch({ strict: false }) as SettingsSearch;
   const section = search.settingsSection ?? "general";
   const runtime = useAppStore((state) => state.runtime);
-  const sidebarCollapsed = useAppStore((state) => state.sidebarCollapsed);
-  const setSidebarCollapsed = useAppStore((state) => state.setSidebarCollapsed);
   const workspacesLoaded = useAppStore((state) => state.workspacesLoaded);
   const setRuntime = useAppStore((state) => state.setRuntime);
   const workspaces = useAppStore((state) => state.workspaces);
@@ -97,67 +92,31 @@ function SettingsRoute() {
     });
 
   return (
-    <div
-      className={cn(
-        "group app-shell !grid !h-full !w-full !min-h-0 !overflow-hidden",
-        sidebarCollapsed && "app-shell-sidebar-collapsed",
+    <>
+      {!runtime && !workspacesLoaded ? (
+        <SettingsContentSkeleton />
+      ) : (
+        <GlobalSettings
+          section={section}
+          runtime={runtime}
+          workspaces={workspaces}
+          discovery={discovery}
+          insightsStatus={insightsStatus}
+          quotaStatus={quotaStatus}
+          remoteGateways={remoteGateways}
+          scanRoots={scanRoots}
+          excluded={excluded}
+          activity={activity}
+          onAddRoot={addRoot}
+          onRemoveRoot={removeRoot}
+          onRestore={restoreExcluded}
+          onCloseBehaviorChanged={changeCloseBehavior}
+          onLocaleChanged={changeRuntime}
+          onOnboardingRestarted={restartOnboarding}
+          onRemoteGatewaysChanged={refreshRemoteGateways}
+        />
       )}
-    >
-      <WindowToolbar />
-      <SettingsSidebar
-        active={section}
-        collapsed={sidebarCollapsed}
-        onSelect={setSection}
-        onBack={() => void navigate({ to: "/" })}
-        onSettings={() => setSection("general")}
-        onCollapsedChange={setSidebarCollapsed}
-      />
-      <main
-        className={cn(
-          "app-shell-main !col-start-2 !row-start-3 !flex !min-h-0 !min-w-0 !h-full !flex-col !overflow-hidden !text-sm",
-          `settings-section-${section}`,
-        )}
-      >
-        <div className="page-scroll-container min-h-0 flex-1">
-          {message && (
-            <div className="mx-7 mt-3 flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
-              <CircleAlert size={17} />
-              {message}
-            </div>
-          )}
-          <section
-            className={cn(
-              "mx-auto grid w-full max-w-[1180px] gap-5 px-7 pb-10 pt-[22px] max-[900px]:px-[18px]",
-              section === "general" && "pt-4",
-            )}
-          >
-            {!runtime && !workspacesLoaded ? (
-              <SettingsContentSkeleton />
-            ) : (
-              <GlobalSettings
-                section={section}
-                runtime={runtime}
-                workspaces={workspaces}
-                discovery={discovery}
-                insightsStatus={insightsStatus}
-                quotaStatus={quotaStatus}
-                remoteGateways={remoteGateways}
-                scanRoots={scanRoots}
-                excluded={excluded}
-                activity={activity}
-                onAddRoot={addRoot}
-                onRemoveRoot={removeRoot}
-                onRestore={restoreExcluded}
-                onCloseBehaviorChanged={changeCloseBehavior}
-                onLocaleChanged={changeRuntime}
-                onOnboardingRestarted={restartOnboarding}
-                onRemoteGatewaysChanged={refreshRemoteGateways}
-              />
-            )}
-          </section>
-        </div>
-      </main>
-    </div>
+    </>
   );
 }
 

--- a/apps/desktop/src/routes/workspace/$workspaceId/route.tsx
+++ b/apps/desktop/src/routes/workspace/$workspaceId/route.tsx
@@ -37,6 +37,7 @@ import {
   WorkspaceSessionsSkeleton,
 } from "@/features/workspace/WorkspaceSkeleton";
 import { AppSidebar, type SidebarEntry } from "@/components/AppSidebar";
+import { AppShellHeader } from "@/features/app/AppShell";
 import { useAppDialogs } from "@/components/AppDialogProvider";
 import { WindowToolbar } from "@/components/WindowToolbar";
 import { useAppStore } from "../../../stores/app-store";
@@ -339,7 +340,6 @@ function WorkspaceLayout() {
       : entry,
   );
   const sidebarCollapsed = app.sidebarCollapsed;
-  const setSidebarCollapsed = app.setSidebarCollapsed;
   const shellClass = cn(
     "group app-shell !grid !h-full !w-full !min-h-0 !overflow-hidden",
     sidebarCollapsed && "app-shell-sidebar-collapsed",
@@ -361,6 +361,7 @@ function WorkspaceLayout() {
   return (
     <div className={shellClass}>
       <WindowToolbar />
+      <AppShellHeader />
       <AppSidebar
         active="workspaces"
         collapsed={sidebarCollapsed}
@@ -377,7 +378,6 @@ function WorkspaceLayout() {
           });
         }}
         onBrandClick={() => navigateGlobal("home")}
-        onCollapsedChange={setSidebarCollapsed}
       />
       <main className={mainClass}>
         <div className="page-scroll-container min-h-0 flex-1">


### PR DESCRIPTION
Keep the desktop app shell mounted when navigating between global pages and Settings.

- Add a shared AppShell for global and settings routes
- Keep the window toolbar, header divider, and collapse button stable
- Replace only the sidebar content and route outlet during navigation
- Centralize the sidebar collapse control
- Preserve existing keyboard shortcut behavior

Validation:
- pnpm typecheck
- pnpm --filter @agentkib test
- pnpm build
- 21 test files passed, 90 tests passed