### PR TITLE
chore(release): 准备 v0.6.0

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -723,21 +723,12 @@ jobs:
           if [[ -n "$release_json" ]]; then
             echo "Resuming existing draft release $RELEASE_TAG"
           else
-            release_notes=$(
-              cat <<'EOF'
-          > [!NOTE]
-          > macOS 安装包已使用 AgentKib 的 Developer ID Application 证书签名并通过 Apple 公证，可直接拖入“应用程序”后打开。
-          >
-          > The macOS packages are signed with AgentKib's Developer ID Application certificate and notarized by Apple. Drag AgentKib into Applications and open it normally.
-          EOF
-            )
             create_args=(
               release create "$RELEASE_TAG"
               --repo "$GITHUB_REPOSITORY"
               --target "$RELEASE_SHA"
               --title "AgentKib $RELEASE_TAG"
               --generate-notes
-              --notes "$release_notes"
               --verify-tag
               --draft
             )

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agentkib-adapters"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-core",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-conversations"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-discovery"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-gateways"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-git"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-insights"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-mcp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-platform"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "hex",
  "libc",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-protocol"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-quota"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-runtime"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-conversations",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-storage"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agentkib-platform",
  "chrono",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-store"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "agentkib-conversations",
  "agentkib-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "MIT"
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentkib/desktop",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Desktop app for discovering, diagnosing, and synchronizing coding agent configuration.",
   "author": "AgentKib contributors",
   "homepage": "https://github.com/starroyhq/agentkib",

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -38,7 +38,7 @@ tags such as `v0.1.0` become the latest release. Tags containing a prerelease
 suffix, such as `v0.2.0-beta.1`, are published as prereleases.
 
 The workflow refuses to publish when the tag does not exactly match the
-desktop version, the three version sources differ, or the tagged commit is not
+desktop version, the two version sources differ, or the tagged commit is not
 contained in `origin/main`. Every build job checks out the same resolved commit.
 
 ## Retry a failed release


### PR DESCRIPTION
## 修改摘要

- 将桌面端与 Rust workspace 版本更新到 0.6.0
- 更新 Cargo.lock 中的 workspace 包版本
- 移除 Release Note 中每个版本重复的静态 macOS 前言，保留 GitHub 自动生成的版本差异
- 修正文档中的版本源数量

## 验证

- cargo fmt --all -- --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- pnpm test
- pnpm typecheck
- pnpm build
- node --test .github/scripts/*.test.mjs