### PR TITLE
fix(release): 兼容 Electron macOS 签名身份

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -325,7 +325,7 @@ jobs:
             if [[ "$SHOULD_PUBLISH" == true ]]; then
               export CSC_LINK="$APPLE_CERTIFICATE"
               export CSC_KEY_PASSWORD="$APPLE_CERTIFICATE_PASSWORD"
-              export CSC_NAME="$APPLE_SIGNING_IDENTITY"
+              export CSC_NAME="${APPLE_SIGNING_IDENTITY#Developer ID Application: }"
               export APPLE_API_KEY="$APPLE_API_KEY_PATH"
               args+=(--config.mac.notarize=true)
             fi


### PR DESCRIPTION
## 根因

`APPLE_SIGNING_IDENTITY` 保存的是 codesign 使用的完整 Authority（包含 `Developer ID Application: ` 前缀），electron-builder 26 会拒绝该前缀，导致 v0.6.0 的 macOS x64/ARM64 构建失败。

## 修复

仅在赋值给 `CSC_NAME` 时移除该前缀；后续 `codesign` 校验仍使用完整 Authority。

## 验证

- Bash 参数展开：带前缀时正确移除，不带前缀时保持原值
- Workflow YAML 语法解析通过
- Release helper 测试 7/7 通过
- v0.6.0 首次发布中 Linux、Fedora、Windows x64/ARM64 均已通过，失败仅限两个 macOS job