### PR TITLE
fix(release): 修正 Electron Linux 产物清单

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -640,12 +640,12 @@ jobs:
           ${prefix}_linux-arm64.AppImage.sha256
           ${prefix}_linux-arm64.deb
           ${prefix}_linux-arm64.deb.sha256
-          ${prefix}_linux-x64.AppImage
-          ${prefix}_linux-x64.AppImage.sha256
-          ${prefix}_linux-x64.deb
-          ${prefix}_linux-x64.deb.sha256
-          ${prefix}_linux-x64.rpm
-          ${prefix}_linux-x64.rpm.sha256
+          ${prefix}_linux-x86_64.AppImage
+          ${prefix}_linux-x86_64.AppImage.sha256
+          ${prefix}_linux-amd64.deb
+          ${prefix}_linux-amd64.deb.sha256
+          ${prefix}_linux-x86_64.rpm
+          ${prefix}_linux-x86_64.rpm.sha256
           ${prefix}_macos-arm64.dmg
           ${prefix}_macos-arm64.dmg.sha256
           ${prefix}_macos-arm64.zip
@@ -669,9 +669,14 @@ jobs:
           find "$RELEASE_ASSETS_DIR" -maxdepth 1 -type f -exec basename {} \; \
             | LC_ALL=C sort > "$RUNNER_TEMP/actual-release-assets.txt"
 
+          missing_required_asset=false
           while IFS= read -r required; do
-            test -s "$RELEASE_ASSETS_DIR/$required"
+            if [[ ! -s "$RELEASE_ASSETS_DIR/$required" ]]; then
+              echo "Missing required release artifact: $required" >&2
+              missing_required_asset=true
+            fi
           done < "$RUNNER_TEMP/required-release-assets.txt"
+          [[ "$missing_required_asset" == false ]]
 
           while IFS= read -r actual; do
             case "$actual" in


### PR DESCRIPTION
## 修改摘要

- 对齐 Electron Builder 的 Linux x64 原生产物名：AppImage/RPM 使用 `x86_64`，DEB 使用 `amd64`
- 发布校验缺少产物时打印明确文件名，避免静默失败

## 验证

- `ruby -e "require \yaml\; YAML.parse_file(\\.github/workflows/release-desktop.yml\)"`\n- `node --test .github/scripts/*.test.mjs`（7/7）\n- `git diff --check`\n- 已与 v0.6.0 成功构建任务中的实际产物名逐项核对