### PR TITLE
fix(release): 等待 Windows 应用进程完全退出

### DIFF
--- a/.github/scripts/smoke-test-windows-installer.ps1
+++ b/.github/scripts/smoke-test-windows-installer.ps1
@@ -82,6 +82,22 @@ function Find-AgentKibExecutable {
   return $null
 }
 
+function Stop-AgentKibProcesses {
+  $stopDeadline = (Get-Date).AddSeconds(15)
+  do {
+    $runningProcesses = @(Get-Process -Name "AgentKib" -ErrorAction SilentlyContinue)
+    if ($runningProcesses.Count -eq 0) {
+      return
+    }
+    $runningProcesses | Stop-Process -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Milliseconds 250
+  } while ((Get-Date) -lt $stopDeadline)
+
+  $remainingProcessIds = @(Get-Process -Name "AgentKib" -ErrorAction SilentlyContinue |
+    Select-Object -ExpandProperty Id)
+  throw "AgentKib processes remained after termination: $($remainingProcessIds -join ', ')"
+}
+
 Install-AgentKib
 $executable = Find-AgentKibExecutable
 if (-not $executable) {
@@ -104,10 +120,7 @@ if (-not $SkipLaunch) {
   if ($app.HasExited) {
     throw "Installed AgentKib exited during startup with code $($app.ExitCode)"
   }
-  Stop-Process -Id $app.Id -Force
-  $app.WaitForExit()
-  Get-Process -Name "AgentKib" -ErrorAction SilentlyContinue |
-    Stop-Process -Force -ErrorAction SilentlyContinue
+  Stop-AgentKibProcesses
 }
 
 $dataDirectory = Join-Path $env:LOCALAPPDATA "ai.agentkib"
@@ -119,6 +132,7 @@ Install-AgentKib
 if (-not (Test-Path -LiteralPath $sentinel)) {
   throw "User data was removed by an overwrite installation"
 }
+Stop-AgentKibProcesses
 
 $installationRoot = Split-Path -Parent $executable.FullName
 $uninstaller = Get-ChildItem -LiteralPath $installationRoot -Filter "Uninstall*.exe" -File |

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -245,6 +245,14 @@ jobs:
         with:
           ref: ${{ needs.preflight.outputs.release_sha }}
 
+      - name: Checkout Windows release helper scripts
+        if: runner.os == 'Windows'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.sha }}
+          path: .release-helpers
+          sparse-checkout: .github/scripts
+
       - name: Install Linux desktop dependencies
         if: runner.os == 'Linux'
         run: |
@@ -359,12 +367,12 @@ jobs:
       - name: Smoke test Windows x64 installer
         if: runner.os == 'Windows' && matrix.arch == 'x64'
         shell: pwsh
-        run: ./.github/scripts/smoke-test-windows-installer.ps1 -SearchRoot apps/desktop/release-electron
+        run: ./.release-helpers/.github/scripts/smoke-test-windows-installer.ps1 -SearchRoot apps/desktop/release-electron
 
       - name: Smoke test Windows ARM64 preview installer
         if: runner.os == 'Windows' && matrix.arch == 'arm64-preview'
         shell: pwsh
-        run: ./.github/scripts/smoke-test-windows-installer.ps1 -SearchRoot apps/desktop/release-electron -SkipQuota
+        run: ./.release-helpers/.github/scripts/smoke-test-windows-installer.ps1 -SearchRoot apps/desktop/release-electron -SkipQuota
 
       - name: Verify macOS application bundle
         if: runner.os == 'macOS'


### PR DESCRIPTION
## 修改摘要

- 将 Windows 安装器冒烟测试的进程终止改为有界轮询，确保所有 `AgentKib` 进程真正退出
- 覆盖安装后、卸载前再次收敛进程，避免 NSIS 因可执行文件被占用而残留
- Windows 发布 job 单独从 workflow 触发提交检出辅助脚本；应用源码仍固定使用 release tag
- 保留原有卸载结果和用户数据保留断言

## 背景

`v0.6.0` 发布重跑连续两次在卸载后检测到 `AgentKib.exe` 残留；脚本此前终止额外 Electron 进程后未等待其退出。手动重跑会检出不可变 tag，因此需显式加载 `main` 上修复后的发布辅助脚本。

## 验证

- `node --test .github/scripts/*.test.mjs`（7/7）
- workflow YAML 解析通过
- `git diff --check`
- 本机未安装 PowerShell，完整 Windows 安装/卸载行为由发布重跑验证