### PR TITLE
chore(release): 准备 v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agentkib-adapters"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-core",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-conversations"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-discovery"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-gateways"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-git"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-insights"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-mcp"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-platform"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "hex",
  "libc",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-protocol"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-quota"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-runtime"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-conversations",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-storage"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentkib-platform",
  "chrono",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-store"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agentkib-conversations",
  "agentkib-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "MIT"
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentkib/desktop",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Desktop app for discovering, diagnosing, and synchronizing coding agent configuration.",
   "author": "AgentKib contributors",
   "homepage": "https://github.com/starroyhq/agentkib",


### PR DESCRIPTION
## 修改摘要

- 将 Rust workspace 版本提升到 `0.7.0`
- 将 Electron 桌面应用版本提升到 `0.7.0`
- 同步 `Cargo.lock` 中 workspace crate 版本
- 不包含 Tauri 兼容产物或 `latest.json`

## 验证

- `cargo check -p agentkib-runtime`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm install --frozen-lockfile`
- `pnpm test`（33 files / 126 tests）
- `pnpm typecheck`
- `pnpm build`
- `node --test .github/scripts/*.test.mjs`（7/7）
- release workflow YAML 解析通过
- `git diff --check`