### PR TITLE
fix(updater): 修复更新说明显示原始 HTML

### DIFF
--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -20,6 +20,7 @@ import { ElectronNativeShell, resolveNativeShellTrayIcon } from "./native-shell"
 import { ElectronRefreshCoordinator } from "./refresh-coordinator";
 import { StartupBenchmark } from "./startup-benchmark";
 import { firstCloseDecision } from "./close-behavior";
+import { normalizeReleaseNotes } from "./release-notes";
 import {
   optionalCloseBehavior,
   optionalPositiveInteger,
@@ -332,21 +333,11 @@ function registerUpdateIpc(): void {
       return undefined;
     }
     pendingUpdateVersion = update.version;
-    const releaseNotes = update.releaseNotes;
-    const notes =
-      typeof releaseNotes === "string"
-        ? releaseNotes
-        : Array.isArray(releaseNotes)
-          ? releaseNotes
-              .map((entry) => entry.note ?? "")
-              .filter(Boolean)
-              .join("\n\n") || undefined
-          : undefined;
     return {
       current_version: app.getVersion(),
       version: update.version,
       published_at: update.releaseDate || undefined,
-      notes,
+      notes: normalizeReleaseNotes(update.releaseNotes),
       release_url: `https://github.com/starroyhq/agentkib/releases/tag/v${update.version}`,
       install_mode: process.platform === "linux" && !process.env.APPIMAGE ? "manual" : "in-app",
     };

--- a/apps/desktop/electron/main/release-notes.test.ts
+++ b/apps/desktop/electron/main/release-notes.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { normalizeReleaseNotes } from "./release-notes";
+
+describe("normalizeReleaseNotes", () => {
+  it("converts GitHub release HTML into readable plain text", () => {
+    const releaseNotes = [
+      "<h2>What's Changed</h2>",
+      "<ul>",
+      '<li>fix(release): support macOS signing by <a href="https://github.com/example">@example</a> in <a href="https://github.com/example/project/pull/38">#38</a></li>',
+      "</ul>",
+      '<p><strong>Full Changelog</strong>: <a href="https://github.com/example/project/compare/v0.6.0...v0.7.0"><code>v0.6.0...v0.7.0</code></a></p>',
+    ].join("");
+
+    expect(normalizeReleaseNotes(releaseNotes)).toBe(
+      [
+        "What's Changed",
+        "",
+        "- fix(release): support macOS signing by @example in #38",
+        "",
+        "Full Changelog: v0.6.0...v0.7.0",
+      ].join("\n"),
+    );
+  });
+
+  it("normalizes every entry and decodes HTML entities", () => {
+    expect(
+      normalizeReleaseNotes([
+        { note: "<p>First &amp; second</p>" },
+        { note: "<ul><li>编号 &#35;42</li></ul>" },
+        { note: "" },
+      ]),
+    ).toBe("First & second\n\n- 编号 #42");
+  });
+
+  it("preserves plain-text release notes", () => {
+    const releaseNotes = "## What's Changed\n\n- Fix updater rendering";
+
+    expect(normalizeReleaseNotes(releaseNotes)).toBe(releaseNotes);
+  });
+
+  it("removes executable element contents", () => {
+    expect(normalizeReleaseNotes("<p>Safe</p><script>alert('unsafe')</script>")).toBe("Safe");
+  });
+});

--- a/apps/desktop/electron/main/release-notes.ts
+++ b/apps/desktop/electron/main/release-notes.ts
@@ -1,0 +1,68 @@
+interface ReleaseNoteEntry {
+  note?: string | null;
+}
+
+const HTML_RELEASE_NOTE_PATTERN =
+  /<\/?(?:a|blockquote|br|code|div|em|h[1-6]|hr|li|ol|p|pre|strong|ul)\b/i;
+
+const HTML_ENTITIES: Record<string, string> = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  nbsp: " ",
+  quot: '"',
+};
+
+export function normalizeReleaseNotes(
+  releaseNotes: string | readonly ReleaseNoteEntry[] | null | undefined,
+): string | undefined {
+  const entries = typeof releaseNotes === "string" ? [releaseNotes] : (releaseNotes ?? []);
+  const notes = entries
+    .map((entry) => normalizeReleaseNote(typeof entry === "string" ? entry : entry.note))
+    .filter((note): note is string => Boolean(note));
+
+  return notes.join("\n\n") || undefined;
+}
+
+function normalizeReleaseNote(note: string | null | undefined): string | undefined {
+  const normalized = note?.replace(/\r\n?/g, "\n").trim();
+  if (!normalized) return undefined;
+  if (!HTML_RELEASE_NOTE_PATTERN.test(normalized)) return normalized;
+
+  const text = normalized
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, "")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<li\b[^>]*>/gi, "- ")
+    .replace(/<\/li\s*>/gi, "\n")
+    .replace(/<\/(?:h[1-6]|p)\s*>/gi, "\n\n")
+    .replace(/<\/(?:blockquote|div|ol|pre|ul)\s*>/gi, "\n")
+    .replace(/<hr\b[^>]*>/gi, "\n")
+    .replace(/<[^>]+>/g, "");
+
+  const decoded = decodeHtmlEntities(text);
+  const compacted = decoded
+    .split("\n")
+    .map((line) => line.replace(/[\t ]+/g, " ").trim())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  return compacted || undefined;
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value.replace(/&(#(?:x[\da-f]+|\d+)|[a-z]+);/gi, (entity, name: string) => {
+    if (name.startsWith("#")) {
+      const hexadecimal = name[1]?.toLowerCase() === "x";
+      const codePoint = Number.parseInt(name.slice(hexadecimal ? 2 : 1), hexadecimal ? 16 : 10);
+      if (Number.isSafeInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10ffff) {
+        return String.fromCodePoint(codePoint);
+      }
+      return entity;
+    }
+
+    return HTML_ENTITIES[name.toLowerCase()] ?? entity;
+  });
+}


### PR DESCRIPTION
## 修改摘要

- 在 Electron 更新 IPC 边界将 GitHub Release HTML 转换为可读纯文本
- 保留纯文本更新说明，并兼容数组形式的 release notes
- 解码常用 HTML 实体并移除脚本、样式内容
- 补充 GitHub Release HTML、实体、纯文本和不安全元素的回归测试

## 验证

- pnpm --filter @agentkib/desktop exec vitest run（34 个测试文件、130 个测试通过）
- pnpm typecheck
- pnpm --filter @agentkib/desktop electron:build
- pnpm exec oxfmt --check apps/desktop/electron/main/index.ts apps/desktop/electron/main/release-notes.ts apps/desktop/electron/main/release-notes.test.ts
- pnpm exec oxlint apps/desktop/electron/main/index.ts apps/desktop/electron/main/release-notes.ts apps/desktop/electron/main/release-notes.test.ts
- git diff --check