### PR TITLE
fix(desktop): prevent layout switch in narrow windows

### DIFF
--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -66,9 +66,9 @@ let closePromptOpen = false;
 let benchmarkCompletionStarted = false;
 const startupBenchmark = new StartupBenchmark();
 
-// Native window decorations can reduce the renderer viewport on Windows and Linux.
-// Leave enough room for it to stay above its 1024px compact breakpoint.
-const MAIN_WINDOW_MIN_WIDTH = process.platform === "darwin" ? 1024 : 1038;
+// Keep the desktop window comfortably above the renderer's 1024px compact breakpoint.
+// 1280px is Tailwind's default `xl` breakpoint and leaves room for the desktop layout.
+const MAIN_WINDOW_MIN_WIDTH = 1280;
 
 interface ElectronRuntimeInfo {
   close_behavior?: "minimize-to-tray" | "quit";

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -66,6 +66,9 @@ let closePromptOpen = false;
 let benchmarkCompletionStarted = false;
 const startupBenchmark = new StartupBenchmark();
 
+// Keep the native window above the renderer's compact-layout breakpoint.
+const MAIN_WINDOW_MIN_WIDTH = 1024;
+
 interface ElectronRuntimeInfo {
   close_behavior?: "minimize-to-tray" | "quit";
   app_icon_preference?: "white" | "black";
@@ -746,7 +749,7 @@ async function createMainWindow(): Promise<void> {
     title: "AgentKib",
     width: 1360,
     height: 860,
-    minWidth: 900,
+    minWidth: MAIN_WINDOW_MIN_WIDTH,
     minHeight: 680,
     show: false,
     backgroundColor: "#0a0a0a",

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -66,8 +66,9 @@ let closePromptOpen = false;
 let benchmarkCompletionStarted = false;
 const startupBenchmark = new StartupBenchmark();
 
-// Keep the native window above the renderer's compact-layout breakpoint.
-const MAIN_WINDOW_MIN_WIDTH = 1024;
+// Native window decorations can reduce the renderer viewport on Windows and Linux.
+// Leave enough room for it to stay above its 1024px compact breakpoint.
+const MAIN_WINDOW_MIN_WIDTH = process.platform === "darwin" ? 1024 : 1038;
 
 interface ElectronRuntimeInfo {
   close_behavior?: "minimize-to-tray" | "quit";


### PR DESCRIPTION
将 Electron 主窗口的最小宽度统一设置为 1280px，避免窗口缩小时进入 1024px 以下的紧凑布局。

- 覆盖 macOS、Windows 和 Linux
- 为 Windows/Linux 原生窗口边框预留足够空间
- 保持现有最小高度 680px 不变
- 与 Tailwind 默认 `xl` 宽度断点保持一致

验证：
- `git diff --check` 通过
- 未新增测试