### PR TITLE
chore(release): 准备 v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agentkib-adapters"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-core",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-conversations"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-discovery"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-gateways"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-git"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-insights"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-mcp"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agentkib-conversations",
  "agentkib-core",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-platform"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "hex",
  "libc",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-protocol"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-quota"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-runtime"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-conversations",
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-skills"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-storage"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agentkib-platform",
  "chrono",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-store"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agentkib-conversations",
  "agentkib-core",
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-tools"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 license = "MIT"
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentkib/desktop",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Desktop app for discovering, diagnosing, and synchronizing coding agent configuration.",
   "author": "AgentKib contributors",
   "homepage": "https://github.com/starroyhq/agentkib",


### PR DESCRIPTION
## 修改摘要

- 将 Rust workspace 版本提升到 `0.8.0`
- 将 Electron 桌面应用版本提升到 `0.8.0`
- 同步 `Cargo.lock` 中 workspace crate 版本
- 不包含设计稿、QA 图片或其他未跟踪文件

## 验证

- `cargo check -p agentkib-runtime`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm install --frozen-lockfile`
- `pnpm format:check`
- `pnpm lint`（通过，仅有既有 warning）
- `pnpm test`（44 files / 177 tests）
- `pnpm typecheck`
- `pnpm build`
- `node --test .github/scripts/*.test.mjs`（7/7）
- release workflow YAML 解析通过
- `git diff --check`

## 风险与回滚

仅同步版本号，不改变运行时行为。发布 tag 不移动；若正式产物发现缺陷，按发布规范使用新的 patch 版本修复。