### PR TITLE
fix(release): 延长 Windows 卸载清理等待时间

### DIFF
--- a/.github/scripts/smoke-test-windows-installer.ps1
+++ b/.github/scripts/smoke-test-windows-installer.ps1
@@ -144,7 +144,10 @@ $uninstall = Start-Process -FilePath $uninstaller.FullName -ArgumentList "/S" -W
 if ($uninstall.ExitCode -ne 0) {
   throw "AgentKib uninstaller failed with exit code $($uninstall.ExitCode)"
 }
-$uninstallDeadline = (Get-Date).AddSeconds(30)
+# NSIS performs the final removal from a detached cleanup process after the
+# launcher exits. Hosted Windows runners can take longer than 30 seconds to
+# release the installed executable while antivirus scanning is active.
+$uninstallDeadline = (Get-Date).AddMinutes(2)
 while ((Test-Path -LiteralPath $executable.FullName) -and (Get-Date) -lt $uninstallDeadline) {
   Start-Sleep -Milliseconds 500
 }


### PR DESCRIPTION
## Summary
- extend the Windows NSIS uninstall cleanup deadline from 30 seconds to 2 minutes
- keep the existing assertion that AgentKib.exe must be removed
- document the detached NSIS cleanup and hosted-runner antivirus delay

## Validation
- `git diff --check`
- `node --test .github/scripts/*.test.mjs`
- parsed all GitHub Actions workflow YAML files
- Windows behavior will be verified by Windows Checks and the release candidate rerun

## Context
The v0.8.0 candidate passed on retry, but the tagged release reproduced the 30-second cleanup timeout. The release workflow supports checking out helper scripts from the dispatch revision, so this fix can be merged to main and used to republish the existing immutable v0.8.0 tag without moving it.