### PR TITLE
fix(updater): 修复应用内更新无法重启

### DIFF
--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -42,7 +42,10 @@ protocol.registerSchemesAsPrivileged([
   },
 ]);
 
-const appFlavor = process.env.AGENTKIB_DEV === "1" ? "ai.agentkib.dev" : "ai.agentkib";
+const isDevelopmentApp = process.env.AGENTKIB_DEV === "1" || !app.isPackaged;
+const appDisplayName = isDevelopmentApp ? "AgentKib Dev" : "AgentKib";
+const appFlavor = isDevelopmentApp ? "ai.agentkib.dev" : "ai.agentkib";
+app.setName(appDisplayName);
 const electronDataPath =
   process.env.AGENTKIB_BENCHMARK_USER_DATA ??
   path.join(app.getPath("appData"), appFlavor, "electron");
@@ -121,7 +124,6 @@ nativeTheme.on("updated", () => {
 
 async function startApplication(): Promise<void> {
   startupBenchmark.mark("app-ready");
-  if (process.env.AGENTKIB_DEV === "1") app.setName("AgentKib Dev");
   await registerRendererProtocol();
 
   runtimeHost = new DesktopRuntimeHost({
@@ -129,7 +131,7 @@ async function startApplication(): Promise<void> {
     clientVersion: app.getVersion(),
     environment: {
       AGENTKIB_APP_FLAVOR: appFlavor,
-      AGENTKIB_APP_NAME: process.env.AGENTKIB_DEV === "1" ? "AgentKib Dev" : "AgentKib",
+      AGENTKIB_APP_NAME: appDisplayName,
       AGENTKIB_APP_VERSION: app.getVersion(),
       AGENTKIB_LOCALE: normalizeSystemLocale(app.getLocale()),
       AGENTKIB_SYSTEM_THEME: nativeTheme.shouldUseDarkColors ? "dark" : "light",

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import {
   app,
+  autoUpdater as nativeAutoUpdater,
   BrowserWindow,
   dialog,
   ipcMain,
@@ -322,7 +323,7 @@ function registerUpdateIpc(): void {
   const updaterChannel =
     process.platform === "darwin" || process.platform === "win32" ? process.arch : undefined;
   if (updaterChannel) autoUpdater.channel = updaterChannel;
-  (autoUpdater as import("node:events").EventEmitter).on("before-quit-for-update", () => {
+  nativeAutoUpdater.on("before-quit-for-update", () => {
     quitApproved = true;
   });
   autoUpdater.autoDownload = false;

--- a/apps/desktop/src/features/settings/AgentToolsSettings.tsx
+++ b/apps/desktop/src/features/settings/AgentToolsSettings.tsx
@@ -648,13 +648,13 @@ function AppUpdateSetting({
 }) {
   const dialogs = useAppDialogs();
   const [status, setStatus] = useState<
-    "idle" | "checking" | "up-to-date" | "available" | "downloading" | "failed"
+    "idle" | "checking" | "up-to-date" | "available" | "downloading" | "installing" | "failed"
   >("idle");
   const [update, setUpdate] = useState<AppUpdateInfo>();
   const [error, setError] = useState("");
   const [downloaded, setDownloaded] = useState(0);
   const [contentLength, setContentLength] = useState<number>();
-  const busy = status === "checking" || status === "downloading";
+  const busy = status === "checking" || status === "downloading" || status === "installing";
   const progress = contentLength
     ? Math.min(100, Math.round((downloaded / contentLength) * 100))
     : 0;
@@ -703,8 +703,11 @@ function AppUpdateSetting({
           setDownloaded(event.data.downloaded);
           setContentLength(event.data.content_length);
         }
+        if (event.event === "finished") setStatus("installing");
       });
-      setStatus("up-to-date");
+      // quitAndInstall returns after handing off to the native updater. The old
+      // process cannot claim success until the updated application starts.
+      setStatus("installing");
     } catch (reason) {
       setError(localizeMessage(reason));
       setStatus("failed");
@@ -725,6 +728,7 @@ function AppUpdateSetting({
       return contentLength
         ? tr("settings.updateDownloadingProgress", { progress })
         : tr("settings.updateDownloading");
+    if (status === "installing") return tr("settings.updateInstalling");
     if (status === "failed") return error;
     return tr("settings.updateCurrentVersion", { version: currentVersion ?? "—" });
   }, [contentLength, currentVersion, error, progress, status, update, updatesEnabled]);
@@ -750,7 +754,13 @@ function AppUpdateSetting({
                     : "border-emerald-500/30 bg-emerald-500/8 text-emerald-700 dark:text-emerald-300",
                 )}
               >
-                {status === "failed" ? <CircleAlert size={12} /> : <Check size={12} />}
+                {status === "failed" ? (
+                  <CircleAlert size={12} />
+                ) : busy ? (
+                  <RefreshCw className="animate-spin" size={12} />
+                ) : (
+                  <Check size={12} />
+                )}
                 {tr(`settings.tools.appState.${status}`)}
               </Badge>
             </div>

--- a/apps/desktop/src/features/settings/AppUpdateSetting.test.tsx
+++ b/apps/desktop/src/features/settings/AppUpdateSetting.test.tsx
@@ -122,5 +122,9 @@ describe("AppUpdateSetting", () => {
 
     expect(api.installAppUpdate).toHaveBeenCalledOnce();
     expect(api.installAppUpdate).toHaveBeenCalledWith("0.3.0", expect.any(Function));
+    expect(
+      await screen.findByText("Update downloaded. Quitting AgentKib to install and restart…"),
+    ).toBeTruthy();
+    expect(screen.queryByText("You're up to date (0.2.0)")).toBeNull();
   });
 });

--- a/apps/desktop/src/locales/en-US.json
+++ b/apps/desktop/src/locales/en-US.json
@@ -238,6 +238,7 @@
   "settings.updateAvailable": "Version {{version}} is available; current version is {{current}}",
   "settings.updateDownloading": "Downloading and verifying the update…",
   "settings.updateDownloadingProgress": "Downloading and verifying the update… {{progress}}%",
+  "settings.updateInstalling": "Update downloaded. Quitting AgentKib to install and restart…",
   "settings.updateDownloadInstall": "Download and install",
   "settings.updateOpenRelease": "Open Release download",
   "settings.updateRetry": "Check again",
@@ -1273,5 +1274,6 @@
   "settings.tools.appState.up-to-date": "Up to date",
   "settings.tools.appState.available": "Update available",
   "settings.tools.appState.downloading": "Downloading",
+  "settings.tools.appState.installing": "Restarting",
   "settings.tools.appState.failed": "Check failed"
 }

--- a/apps/desktop/src/locales/ja-JP.json
+++ b/apps/desktop/src/locales/ja-JP.json
@@ -238,6 +238,7 @@
   "settings.updateAvailable": "新しいバージョン {{version}} があります。現在は {{current}} です",
   "settings.updateDownloading": "アップデートをダウンロードして検証しています…",
   "settings.updateDownloadingProgress": "アップデートをダウンロードして検証しています… {{progress}}%",
+  "settings.updateInstalling": "アップデートをダウンロードしました。インストールして再起動するため AgentKib を終了しています…",
   "settings.updateDownloadInstall": "ダウンロードしてインストール",
   "settings.updateOpenRelease": "Release ページを開く",
   "settings.updateRetry": "もう一度確認",
@@ -1273,5 +1274,6 @@
   "settings.tools.appState.up-to-date": "最新版",
   "settings.tools.appState.available": "更新あり",
   "settings.tools.appState.downloading": "ダウンロード中",
+  "settings.tools.appState.installing": "再起動中",
   "settings.tools.appState.failed": "確認失敗"
 }

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -238,6 +238,7 @@
   "settings.updateAvailable": "发现新版本 {{version}}，当前为 {{current}}",
   "settings.updateDownloading": "正在下载并验证更新…",
   "settings.updateDownloadingProgress": "正在下载并验证更新… {{progress}}%",
+  "settings.updateInstalling": "更新已下载，正在退出 AgentKib 以完成安装并重启…",
   "settings.updateDownloadInstall": "下载并安装",
   "settings.updateOpenRelease": "前往 Release 下载",
   "settings.updateRetry": "重新检查",
@@ -1273,5 +1274,6 @@
   "settings.tools.appState.up-to-date": "已是最新",
   "settings.tools.appState.available": "发现更新",
   "settings.tools.appState.downloading": "下载中",
+  "settings.tools.appState.installing": "正在重启",
   "settings.tools.appState.failed": "检查失败"
 }

--- a/apps/desktop/src/locales/zh-TW.json
+++ b/apps/desktop/src/locales/zh-TW.json
@@ -238,6 +238,7 @@
   "settings.updateAvailable": "發現新版本 {{version}}，目前為 {{current}}",
   "settings.updateDownloading": "正在下載並驗證更新…",
   "settings.updateDownloadingProgress": "正在下載並驗證更新… {{progress}}%",
+  "settings.updateInstalling": "更新已下載，正在結束 AgentKib 以完成安裝並重新啟動…",
   "settings.updateDownloadInstall": "下載並安裝",
   "settings.updateOpenRelease": "前往 Release 下載",
   "settings.updateRetry": "重新檢查",
@@ -1273,5 +1274,6 @@
   "settings.tools.appState.up-to-date": "已是最新",
   "settings.tools.appState.available": "發現更新",
   "settings.tools.appState.downloading": "下載中",
+  "settings.tools.appState.installing": "正在重新啟動",
   "settings.tools.appState.failed": "檢查失敗"
 }

--- a/apps/desktop/src/test/startup-flow.test.ts
+++ b/apps/desktop/src/test/startup-flow.test.ts
@@ -79,6 +79,16 @@ describe("desktop startup flow", () => {
     );
   });
 
+  it("uses the product display name instead of the workspace package name", () => {
+    const source = readFileSync(path.join(desktopRoot, "electron/main/index.ts"), "utf8");
+
+    expect(source).toContain(
+      'const appDisplayName = isDevelopmentApp ? "AgentKib Dev" : "AgentKib"',
+    );
+    expect(source).toContain("app.setName(appDisplayName)");
+    expect(source).toContain("AGENTKIB_APP_NAME: appDisplayName");
+  });
+
   it("flushes the handshake response before initializing the MCP Hub", () => {
     const source = readFileSync(
       path.join(repositoryRoot, "crates/agentkib-runtime/src/main.rs"),

--- a/apps/desktop/src/test/startup-flow.test.ts
+++ b/apps/desktop/src/test/startup-flow.test.ts
@@ -69,6 +69,16 @@ describe("desktop startup flow", () => {
     expect(mainSource).toContain("event.sender !== mainWindow.webContents");
   });
 
+  it("approves update quits from Electron's native updater before the Renderer closes", () => {
+    const source = readFileSync(path.join(desktopRoot, "electron/main/index.ts"), "utf8");
+
+    expect(source).toContain("autoUpdater as nativeAutoUpdater");
+    expect(source).toContain('nativeAutoUpdater.on("before-quit-for-update"');
+    expect(source).not.toContain(
+      '(autoUpdater as import("node:events").EventEmitter).on("before-quit-for-update"',
+    );
+  });
+
   it("flushes the handshake response before initializing the MCP Hub", () => {
     const source = readFileSync(
       path.join(repositoryRoot, "crates/agentkib-runtime/src/main.rs"),


### PR DESCRIPTION
## Summary

- 监听 Electron 原生 updater 的 `before-quit-for-update`，确保更新退出绕过普通窗口关闭保护并释放托盘与 Runtime
- 下载完成后显示“正在退出并重启”，避免在新版本尚未启动前误报已更新
- 固定应用显示名：开发版为 `AgentKib Dev`，正式包为 `AgentKib`，避免菜单栏显示 workspace 包名
- 补充四种语言文案和更新生命周期回归测试

## Root cause

`electron-updater` 在执行 `quitAndInstall()` 时，将 `before-quit-for-update` 发到 Electron 原生 `autoUpdater`。此前监听的是 `electron-updater` 包装器，导致 `quitApproved` 未设置，更新退出被普通退出确认流程拦截，托盘进程持续驻留。

非标准开发启动未设置 `AGENTKIB_DEV` 时，Electron 会从 `package.json` 读取 `@agentkib/desktop` 作为应用名。现在统一根据打包状态确定显示名，并在菜单和托盘初始化前设置。

## Validation

- `pnpm format:check`
- `pnpm lint`（无错误，保留仓库既有警告）
- `pnpm test`（44 files / 178 tests；名称修复后相关测试 15 项通过）
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Residual validation

正式签名旧版本到修复版本的 macOS 原生更新重启链路，需要发布候选包后做一次端到端验收。