### PR TITLE
fix(runtime): 修复管道异常恢复及首页错误残留

### DIFF
--- a/apps/desktop/electron/main/runtime-host.test.ts
+++ b/apps/desktop/electron/main/runtime-host.test.ts
@@ -43,6 +43,7 @@ lines.on("line", (line) => {
     process.exit(0);
   }
   if (request.method === "crash") process.exit(14);
+  else if (request.method === "hold") return;
   else respond(request, request.params);
 });
 `;
@@ -51,12 +52,14 @@ describe("DesktopRuntimeHost", () => {
   let directory: string;
   let script: string;
   let hosts: DesktopRuntimeHost[];
+  let children: ChildProcessWithoutNullStreams[];
 
   beforeEach(async () => {
     directory = await mkdtemp(path.join(tmpdir(), "agentkib-runtime-host-"));
     script = path.join(directory, "fake-runtime.cjs");
     await writeFile(script, fakeRuntimeSource);
     hosts = [];
+    children = [];
   });
 
   afterEach(async () => {
@@ -72,15 +75,18 @@ describe("DesktopRuntimeHost", () => {
       clientVersion: "test",
       maxRestarts,
       shutdownTimeoutMs: 200,
-      spawnProcess: (_executablePath, _args, options) =>
-        spawn(process.execPath, [script], {
+      spawnProcess: (_executablePath, _args, options) => {
+        const child = spawn(process.execPath, [script], {
           ...options,
           env: {
             ...options?.env,
             FAKE_RUNTIME_MODE: mode(),
             FAKE_RUNTIME_MARKER: marker,
           },
-        }) as ChildProcessWithoutNullStreams,
+        }) as ChildProcessWithoutNullStreams;
+        children.push(child);
+        return child;
+      },
     });
     hosts.push(host);
     return host;
@@ -128,6 +134,49 @@ describe("DesktopRuntimeHost", () => {
     mode = "ready";
     await expect(host.retry()).resolves.toMatchObject({ protocolVersion: PROTOCOL_VERSION });
     expect(host.status.state).toBe("ready");
+  });
+
+  it("contains startup stdin errors and can retry without a stale error", async () => {
+    let mode = "never-handshake";
+    const host = createHost(() => mode, 0);
+    const starting = expect(host.start()).rejects.toThrow("EPIPE");
+    children[0].stdin.destroy(new Error("EPIPE"));
+    await starting;
+    expect(host.status.state).toBe("failed");
+
+    mode = "ready";
+    await host.retry();
+    expect(host.status).toMatchObject({ state: "ready", restartCount: 0 });
+    expect(host.status.error).toBeUndefined();
+    // Old pipes can emit after the replacement process is already ready.
+    expect(() => children[0].stdin.emit("error", new Error("late EPIPE"))).not.toThrow();
+    await expect(host.request("echo", { recovered: true })).resolves.toEqual({ recovered: true });
+  });
+
+  it("rejects all pending requests on a broken pipe and restarts only once", async () => {
+    const host = createHost(() => "ready", 1);
+    await host.start();
+    const exited = vi.fn();
+    host.on("exit", exited);
+    const first = expect(host.request("hold", {})).rejects.toThrow("EPIPE");
+    const second = expect(host.request("hold", {})).rejects.toThrow("EPIPE");
+    children[0].stdin.destroy(new Error("EPIPE"));
+    await Promise.all([first, second]);
+    await expect(host.request("echo", { recovered: true })).resolves.toEqual({ recovered: true });
+    expect(children).toHaveLength(2);
+    expect(host.status.state).toBe("ready");
+    expect(exited).toHaveBeenCalledTimes(1);
+    expect(exited).toHaveBeenCalledWith(expect.objectContaining({ expected: false }));
+  });
+
+  it("handles synchronous write failure through the same recovery path", async () => {
+    const host = createHost(() => "ready", 0);
+    await host.start();
+    vi.spyOn(children[0].stdin, "write").mockImplementation(() => {
+      throw new Error("synchronous pipe failure");
+    });
+    await expect(host.request("echo", {})).rejects.toThrow("synchronous pipe failure");
+    expect(host.status.state).toBe("failed");
   });
 
   it("cancels startup waiters when stopped", async () => {

--- a/apps/desktop/electron/main/runtime-host.ts
+++ b/apps/desktop/electron/main/runtime-host.ts
@@ -192,6 +192,10 @@ export class DesktopRuntimeHost extends EventEmitter {
     });
     this.#child = child;
 
+    // Writable write callbacks do not consume the stream's subsequent error event.
+    // Keep this listener on the old stream too: a late EPIPE after exit is expected.
+    child.stdin.on("error", (error: Error) => this.#handleProcessFailure(child, error));
+
     child.stderr.setEncoding("utf8");
     child.stderr.on("data", (chunk: string) => process.stderr.write(`[agentkib-runtime] ${chunk}`));
 
@@ -225,16 +229,25 @@ export class DesktopRuntimeHost extends EventEmitter {
       this.emit("ready", handshake);
     } catch (error) {
       const runtimeError = toError(error);
-      if (this.#child === child) {
-        this.#child = undefined;
-        this.#lines?.close();
-        this.#lines = undefined;
-        this.#rejectPending(runtimeError);
-        if (child.exitCode === null) child.kill();
-        this.#scheduleRestart(runtimeError);
-      }
+      this.#handleProcessFailure(child, runtimeError);
       throw runtimeError;
     }
+  }
+
+  #handleProcessFailure(child: ChildProcessWithoutNullStreams, error: Error): void {
+    if (this.#child !== child) return;
+    const wasReady = this.#state === "ready";
+    this.#child = undefined;
+    this.#lines?.close();
+    this.#lines = undefined;
+    this.#handshake = undefined;
+    if (wasReady) this.#readiness = deferred<RuntimeHandshakeResult>();
+    this.#rejectPending(error);
+    // Consumers must invalidate runtime-backed services immediately, even when
+    // the OS process has not delivered its exit event yet.
+    this.emit("exit", { code: child.exitCode, signal: null, expected: this.#state === "stopping" });
+    if (child.exitCode === null) child.kill();
+    this.#scheduleRestart(error);
   }
 
   #requestNow<TResult>(method: string, params: unknown): Promise<TResult> {
@@ -249,11 +262,19 @@ export class DesktopRuntimeHost extends EventEmitter {
         resolve: resolve as (value: unknown) => void,
         reject,
       });
-      child.stdin.write(`${payload}\n`, (error) => {
-        if (!error) return;
+      try {
+        child.stdin.write(`${payload}\n`, (error) => {
+          if (!error) return;
+          this.#pending.delete(id);
+          reject(error);
+          this.#handleProcessFailure(child, error);
+        });
+      } catch (error) {
         this.#pending.delete(id);
-        reject(error);
-      });
+        const runtimeError = toError(error);
+        reject(runtimeError);
+        this.#handleProcessFailure(child, runtimeError);
+      }
     });
   }
 

--- a/apps/desktop/src/features/app/AppRuntimeBridge.test.tsx
+++ b/apps/desktop/src/features/app/AppRuntimeBridge.test.tsx
@@ -138,23 +138,60 @@ describe("AppRuntimeBridge", () => {
     expect(window.localStorage.getItem("agentkib.project")).toBe("/missing/legacy-workspace");
   });
 
-  it("shows an in-window retry action after a terminal Runtime failure", async () => {
-    let statusListener: ((status: DesktopRuntimeStatus) => void) | undefined;
-    const retry = vi.fn().mockResolvedValue(undefined);
-    const desktop = window.agentkibDesktop!;
-    desktop.events.onRuntimeStatus = vi.fn((listener) => {
-      statusListener = listener;
-      return () => undefined;
-    });
-    desktop.runtime.status = vi.fn().mockResolvedValue({
-      state: "failed",
-      restartCount: 3,
-      error: "fixture startup failure",
-    });
-    desktop.runtime.retry = retry;
+  it.each([undefined, "new workspace error"])(
+    "clears only its own startup error after Runtime recovery (new message: %s)",
+    async (newMessage) => {
+      let statusListener: ((status: DesktopRuntimeStatus) => void) | undefined;
+      const retry = vi.fn().mockResolvedValue(undefined);
+      const desktop = window.agentkibDesktop!;
+      desktop.events.onRuntimeStatus = vi.fn((listener) => {
+        statusListener = listener;
+        return () => undefined;
+      });
+      desktop.runtime.status = vi.fn().mockResolvedValue({
+        state: "failed",
+        restartCount: 3,
+        error: "fixture startup failure",
+      });
+      desktop.runtime.retry = retry;
+      runtimeInfo.mockRejectedValue(new Error("fixture startup failure"));
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <AppDialogProvider>
+            <AppRuntimeBridge />
+          </AppDialogProvider>
+        </QueryClientProvider>,
+      );
+
+      expect((await screen.findByRole("alert")).textContent).toContain("本地 Runtime 启动失败");
+      await waitFor(() =>
+        expect(useWorkspaceStore.getState().message).toContain("fixture startup failure"),
+      );
+      fireEvent.click(screen.getByRole("button", { name: "重试" }));
+      await waitFor(() => expect(retry).toHaveBeenCalledOnce());
+
+      runtimeInfo.mockResolvedValue({
+        effective_theme: "light",
+        effective_locale: "zh-CN",
+        accent_theme_preference: "vtron",
+      });
+      if (newMessage) useWorkspaceStore.getState().setMessage(newMessage);
+      await act(async () => statusListener?.({ state: "ready", restartCount: 0 }));
+      await waitFor(() => expect(runtimeInfo).toHaveBeenCalledTimes(2));
+      expect(useAppStore.getState().runtime).toMatchObject({ effective_locale: "zh-CN" });
+      expect(useWorkspaceStore.getState().message).toBe(newMessage ?? "");
+      expect(screen.queryByRole("alert")).toBeNull();
+    },
+  );
+
+  it("clears the old startup error when focus successfully synchronizes Runtime", async () => {
+    window.agentkibDesktop!.runtime.status = vi
+      .fn()
+      .mockResolvedValue({ state: "ready", restartCount: 0 });
     runtimeInfo.mockRejectedValue(new Error("fixture startup failure"));
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-
     render(
       <QueryClientProvider client={queryClient}>
         <AppDialogProvider>
@@ -162,19 +199,20 @@ describe("AppRuntimeBridge", () => {
         </AppDialogProvider>
       </QueryClientProvider>,
     );
-
-    expect((await screen.findByRole("alert")).textContent).toContain("本地 Runtime 启动失败");
-    fireEvent.click(screen.getByRole("button", { name: "重试" }));
-    await waitFor(() => expect(retry).toHaveBeenCalledOnce());
-
+    await waitFor(() =>
+      expect(useWorkspaceStore.getState().message).toContain("fixture startup failure"),
+    );
+    // A failed refresh must keep the diagnostic until the Runtime actually recovers.
+    fireEvent(window, new Event("focus"));
+    await waitFor(() => expect(runtimeInfo).toHaveBeenCalledTimes(2));
+    expect(useWorkspaceStore.getState().message).toContain("fixture startup failure");
     runtimeInfo.mockResolvedValue({
       effective_theme: "light",
       effective_locale: "zh-CN",
       accent_theme_preference: "vtron",
     });
-    statusListener?.({ state: "ready", restartCount: 0 });
-    await waitFor(() => expect(runtimeInfo).toHaveBeenCalledTimes(2));
-    expect(useAppStore.getState().runtime).toMatchObject({ effective_locale: "zh-CN" });
+    fireEvent(window, new Event("focus"));
+    await waitFor(() => expect(useWorkspaceStore.getState().message).toBe(""));
   });
 
   it("migrates a legacy cached accent when Runtime has no preference", async () => {

--- a/apps/desktop/src/features/app/AppRuntimeBridge.tsx
+++ b/apps/desktop/src/features/app/AppRuntimeBridge.tsx
@@ -1,5 +1,5 @@
 import { useI18n } from "@/core/useI18n";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -35,6 +35,13 @@ export function AppRuntimeBridge() {
   const previousRuntimeState = useRef<DesktopRuntimeStatus["state"] | undefined>(undefined);
   const [runtimeStatus, setRuntimeStatus] = useState<DesktopRuntimeStatus>();
   const [retrying, setRetrying] = useState(false);
+  const runtimeErrorMessage = useRef<string | undefined>(undefined);
+  const clearRuntimeError = useCallback(() => {
+    const previous = runtimeErrorMessage.current;
+    runtimeErrorMessage.current = undefined;
+    // A recovered Runtime must not dismiss a newer workspace/action error.
+    if (previous !== undefined) setMessage((current) => (current === previous ? "" : current));
+  }, [setMessage]);
 
   useQuotaQueryEvents();
   useHomeQueryEvents();
@@ -44,10 +51,17 @@ export function AppRuntimeBridge() {
     let disposed = false;
     let initialSyncPending = true;
     const desktop = desktopApi();
+    const reportRuntimeError = (error: unknown) => {
+      if (disposed) return;
+      const message = localizeMessage(error);
+      runtimeErrorMessage.current = message;
+      setMessage(message);
+    };
     const synchronizeRuntime = async () => {
       const widthRevision = useSidebarWidthStore.getState().revision;
       let nextRuntime = await api.runtime();
       if (disposed) return;
+      clearRuntimeError();
       if (nextRuntime.accent_theme_preference == null) {
         try {
           nextRuntime = await api.setAccentThemePreference(accentThemePreference());
@@ -81,9 +95,7 @@ export function AppRuntimeBridge() {
       if (status.state === "ready" && previous && previous !== "ready" && !initialSyncPending) {
         void synchronizeRuntime()
           .then(() => queryClient.invalidateQueries())
-          .catch((error: unknown) => {
-            if (!disposed) setMessage(localizeMessage(error));
-          });
+          .catch(reportRuntimeError);
       }
     };
     const unsubscribers = [
@@ -106,7 +118,7 @@ export function AppRuntimeBridge() {
         }
         await synchronizeRuntime();
       } catch (error) {
-        if (!disposed) setMessage(localizeMessage(error));
+        reportRuntimeError(error);
       } finally {
         initialSyncPending = false;
       }
@@ -115,7 +127,14 @@ export function AppRuntimeBridge() {
       disposed = true;
       unsubscribers.forEach((unsubscribe) => unsubscribe());
     };
-  }, [queryClient, setMenuCommand, setMessage, setNavigationRequest, setRuntime]);
+  }, [
+    clearRuntimeError,
+    queryClient,
+    setMenuCommand,
+    setMessage,
+    setNavigationRequest,
+    setRuntime,
+  ]);
 
   useEffect(() => {
     const refreshRuntime = () => {
@@ -123,6 +142,7 @@ export function AppRuntimeBridge() {
       void api
         .runtime()
         .then(async (runtime) => {
+          clearRuntimeError();
           let nextRuntime =
             runtime.accent_theme_preference == null
               ? await api.setAccentThemePreference(accentThemePreference())
@@ -141,7 +161,7 @@ export function AppRuntimeBridge() {
     };
     window.addEventListener("focus", refreshRuntime);
     return () => window.removeEventListener("focus", refreshRuntime);
-  }, [setRuntime]);
+  }, [clearRuntimeError, setRuntime]);
 
   const hasUnsavedDraft = Boolean(
     workspaceStore.manifest &&
@@ -199,7 +219,11 @@ export function AppRuntimeBridge() {
           setRetrying(true);
           void desktopApi()
             .runtime.retry()
-            .catch((error: unknown) => setMessage(localizeMessage(error)))
+            .catch((error: unknown) => {
+              const message = localizeMessage(error);
+              runtimeErrorMessage.current = message;
+              setMessage(message);
+            })
             .finally(() => setRetrying(false));
         }}
       >


### PR DESCRIPTION
## 变更
- 处理 runtime stdin 的 error 事件、写回调错误与同步异常，统一拒绝未完成请求并按原预算恢复。
- 通过进程身份校验避免旧管道错误与 exit 重复触发恢复；立即通知 runtime 服务不可用。
- runtime 同步成功后仅清除自身遗留错误提示，保留不同的新业务错误。
- 补充启动失败、重试、晚到错误、多请求失败与首页恢复回归测试。

## 验证
- 最新 main 基线上定向测试：18 项通过。
- 本轮修复验证：桌面全量 608 项、Web 58 项通过。
- 类型检查、Electron 主进程/preload 与 renderer 构建通过。
- 修改文件格式检查及 git diff --check 通过。

## 发布边界
- 来源于 v0.9.0 候选包本机验收发现的端口占用故障。
- 不修改端口策略，不纳入设计稿及其他无关改动。
- 修复后的新安装包仍待重新打包验收；本 PR 不代表发布验收完成。