### PR TITLE
chore(release): 准备 v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agentkib-adapters"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -22,7 +22,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-core",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-codex-bridge"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-conversations"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-discovery"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-gateways"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-git"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-insights"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-mcp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agentkib-conversations",
  "agentkib-core",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-platform"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "hex",
  "libc",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-protocol"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-quota"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agentkib-platform",
  "anyhow",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-remote"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-runtime"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agentkib-adapters",
  "agentkib-codex-bridge",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-skills"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-storage"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agentkib-platform",
  "chrono",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-store"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agentkib-conversations",
  "agentkib-core",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "agentkib-tools"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agentkib-core",
  "agentkib-platform",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 license = "MIT"
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agentkib/desktop",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Desktop app for discovering, diagnosing, and synchronizing coding agent configuration.",
   "author": "AgentKib contributors",
   "homepage": "https://github.com/starroyhq/agentkib",


### PR DESCRIPTION
将桌面端及 Rust workspace 版本更新为 0.10.0，同步 Cargo.lock。基于已合并的 PR #66。版本合并及检查通过后运行候选打包验收，再创建不可变 v0.10.0 标签发布。